### PR TITLE
Add initial test configurations and update Talos cluster endpoint

### DIFF
--- a/.github/actions/tofu-ci/action.yaml
+++ b/.github/actions/tofu-ci/action.yaml
@@ -41,4 +41,4 @@ runs:
 
     - name: Check Tofu
       shell: bash
-      run: task tofu:check
+      run: task tf:check

--- a/modules/bootstrap/tests/flux.tftest.hcl
+++ b/modules/bootstrap/tests/flux.tftest.hcl
@@ -1,0 +1,9 @@
+run "random" {
+  module {
+    source = "./tests/harness/random"
+  }
+}
+
+run "test" {
+
+}

--- a/modules/bootstrap/tests/harness/random/main.tf
+++ b/modules/bootstrap/tests/harness/random/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.6.6"
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "3.6.3"
+    }
+  }
+}
+
+variable "length" {
+  type    = number
+  default = 2
+}
+
+resource "random_pet" "this" {
+  length = var.length
+}
+
+output "resource_name" {
+  value = random_pet.this.id
+}

--- a/modules/params-get/outputs.tf
+++ b/modules/params-get/outputs.tf
@@ -1,4 +1,5 @@
 output "values" {
+  sensitive = true
   value = {
     for param in data.aws_ssm_parameter.this :
     param.value.name => param.value.value

--- a/modules/talos-cluster/variables.tf
+++ b/modules/talos-cluster/variables.tf
@@ -18,7 +18,7 @@ variable "cluster_id" {
 variable "cluster_endpoint" {
   description = "The endpoint for the Talos cluster."
   type        = string
-  default     = "https://192.168.10.246:6443"
+  default     = "https://10.10.10.10:6443"
 }
 
 variable "cluster_vip" {

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -6,10 +6,9 @@ vars:
   MODULES_DIR: "{{ .PROJECT_DIR }}/modules"
 
 includes:
-  tofu: .taskfiles/tofu
-  github: .taskfiles/github
-  test: .taskfiles/test
-  workstation: .taskfiles/workstation
+  tf: .taskfiles/tofu
+  gh: .taskfiles/github
+  ws: .taskfiles/workstation
   
 tasks:
   default:


### PR DESCRIPTION
This pull request includes several changes to various Terraform and configuration files. The most important changes involve adding a new test harness, updating sensitive output values, modifying default variable values, and renaming taskfile includes.

### New test harness:

* [`modules/bootstrap/tests/flux.tftest.hcl`](diffhunk://#diff-f5e380d59f5586fb028d63096ba250b1db9f3e84153c5c70b663450e35b8efb1R1-R9): Added a new test harness for running random tests.
* [`modules/bootstrap/tests/harness/random/main.tf`](diffhunk://#diff-ae2d736cdcb70da401d6d17b8f06267c93bfc7f05165d6212fc45b668e4d2171R1-R22): Introduced a new Terraform module for generating random pet names, including required providers and variables.

### Sensitive output values:

* [`modules/params-get/outputs.tf`](diffhunk://#diff-128f76f20f18eec1048d463aa99d5a1e6e4afb0e9f5a942c6f7c2c4f51dc9d56R2): Marked the `values` output as sensitive to enhance security.

### Default variable values:

* [`modules/talos-cluster/variables.tf`](diffhunk://#diff-167e1ece077519ca5187e10d9cf4f91181dfbab251d7f51df23804224e87e3c5L21-R21): Updated the default value of `cluster_endpoint` to a new IP address.

### Taskfile includes renaming:

* [`taskfile.yaml`](diffhunk://#diff-10cb41a63b1f1ed034a2e7b25a6a2d45be64dd30e3d859d448863da2861a66f9L9-R11): Renamed taskfile includes for clarity and consistency.