### PR TITLE
Params get toset

### DIFF
--- a/modules/params-get/main.tf
+++ b/modules/params-get/main.tf
@@ -1,4 +1,4 @@
 data "aws_ssm_parameter" "this" {
-  for_each = var.parameters
-  name     = each.value.name
+  for_each = toset(var.parameters)
+  name     = each.value
 }

--- a/modules/params-get/main.tftest.hcl
+++ b/modules/params-get/main.tftest.hcl
@@ -1,0 +1,27 @@
+variables {
+  aws = {
+    region  = "us-east-2"
+    profile = "terragrunt"
+  }
+
+  parameters = ["/homelab/tofu/test/param1", "/homelab/tofu/test/param2"]
+}
+
+run "test" {
+  command = plan
+
+  assert {
+    condition     = length(data.aws_ssm_parameter.this) == 2
+    error_message = "Expected 2 parameters, got ${length(data.aws_ssm_parameter.this)}"
+  }
+
+  assert {
+    condition     = output.values["/homelab/tofu/test/param1"] == "hello"
+    error_message = "Parameter value does not match expected value."
+  }
+
+  assert {
+    condition     = output.values["/homelab/tofu/test/param2"] == "world"
+    error_message = "Parameter value does not match expected value."
+  }
+}

--- a/modules/params-get/outputs.tf
+++ b/modules/params-get/outputs.tf
@@ -1,7 +1,7 @@
 output "values" {
   sensitive = true
   value = {
-    for param in data.aws_ssm_parameter.this :
-    param.value.name => param.value.value
+    for param_key, param in data.aws_ssm_parameter.this :
+    param_key => param.value
   }
 }

--- a/modules/params-put/main.tftest.hcl
+++ b/modules/params-put/main.tftest.hcl
@@ -21,6 +21,7 @@ variables {
 }
 
 run "test" {
+  command = plan
   assert {
     condition     = aws_ssm_parameter.this["param1"].value == "Hello, world!"
     error_message = "Parameter value does not match expected value."

--- a/modules/talos-cluster/README.md
+++ b/modules/talos-cluster/README.md
@@ -51,7 +51,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_cilium_version"></a> [cilium\_version](#input\_cilium\_version) | The version of Cilium to use. | `string` | `"1.16.5"` | no |
-| <a name="input_cluster_endpoint"></a> [cluster\_endpoint](#input\_cluster\_endpoint) | The endpoint for the Talos cluster. | `string` | `"https://192.168.10.246:6443"` | no |
+| <a name="input_cluster_endpoint"></a> [cluster\_endpoint](#input\_cluster\_endpoint) | The endpoint for the Talos cluster. | `string` | `"https://10.10.10.10:6443"` | no |
 | <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | An ID to provide for the Talos cluster. | `number` | `1` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | A name to provide for the Talos cluster. | `string` | `"cluster"` | no |
 | <a name="input_cluster_node_subnet"></a> [cluster\_node\_subnet](#input\_cluster\_node\_subnet) | The subnet to use for the Talos cluster nodes. | `string` | `"192.168.10.0/24"` | no |


### PR DESCRIPTION
This pull request includes several changes to the `params-get` module to improve parameter handling and testing. The main changes involve updating the way parameters are iterated and adding comprehensive tests.

Key changes:

### Improvements to parameter handling:

* [`modules/params-get/main.tf`](diffhunk://#diff-bb9116fd0844c41886fbc36f87388a0be4696b0feeb913931ac4c44b5958b5d7L2-R3): Changed `for_each` to use `toset(var.parameters)` and updated `name` to `each.value` for better iteration over parameters.
* [`modules/params-get/outputs.tf`](diffhunk://#diff-128f76f20f18eec1048d463aa99d5a1e6e4afb0e9f5a942c6f7c2c4f51dc9d56L4-R5): Updated the output map to use `param_key` instead of `param.value.name` for a clearer key-value mapping.

### Enhancements to testing:

* [`modules/params-get/main.tftest.hcl`](diffhunk://#diff-36e3c099851e5a10fecf9d7a4345ddeef0294b61bd956962174533c9b22b61b7R1-R27): Added new test cases to ensure correct parameter retrieval and validation, including assertions for expected parameter values.
* [`modules/params-put/main.tftest.hcl`](diffhunk://#diff-5765119541d8d513ca13222681bf250ae7fef6cb020daa8ce4fc0465ea1d0709R24): Added a `command = plan` statement to the test run block to ensure the plan command is executed during the test.