### PR TITLE
Talos cluster upgrade trigger

### DIFF
--- a/modules/talos-cluster/README.md
+++ b/modules/talos-cluster/README.md
@@ -8,6 +8,7 @@
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6.6 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.17.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | 2.5 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | 3.2.3 |
 | <a name="requirement_talos"></a> [talos](#requirement\_talos) | 0.7.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | 0.12.1 |
 
@@ -17,6 +18,7 @@
 |------|---------|
 | <a name="provider_helm"></a> [helm](#provider\_helm) | 2.17.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | 2.5.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.3 |
 | <a name="provider_talos"></a> [talos](#provider\_talos) | 0.7.0 |
 | <a name="provider_time"></a> [time](#provider\_time) | 0.12.1 |
 
@@ -33,6 +35,7 @@ No modules.
 | [local_sensitive_file.kubeconfig](https://registry.terraform.io/providers/hashicorp/local/2.5/docs/resources/sensitive_file) | resource |
 | [local_sensitive_file.machineconf](https://registry.terraform.io/providers/hashicorp/local/2.5/docs/resources/sensitive_file) | resource |
 | [local_sensitive_file.talosconfig](https://registry.terraform.io/providers/hashicorp/local/2.5/docs/resources/sensitive_file) | resource |
+| [null_resource.talos_upgrade_trigger](https://registry.terraform.io/providers/hashicorp/null/3.2.3/docs/resources/resource) | resource |
 | [talos_cluster_kubeconfig.this](https://registry.terraform.io/providers/siderolabs/talos/0.7.0/docs/resources/cluster_kubeconfig) | resource |
 | [talos_image_factory_schematic.host_schematic](https://registry.terraform.io/providers/siderolabs/talos/0.7.0/docs/resources/image_factory_schematic) | resource |
 | [talos_machine_bootstrap.this](https://registry.terraform.io/providers/siderolabs/talos/0.7.0/docs/resources/machine_bootstrap) | resource |
@@ -60,12 +63,13 @@ No modules.
 | <a name="input_cluster_vip"></a> [cluster\_vip](#input\_cluster\_vip) | The VIP to use for the Talos cluster. Applied to the first interface of control plane hosts. | `string` | `""` | no |
 | <a name="input_gateway_api_version"></a> [gateway\_api\_version](#input\_gateway\_api\_version) | The version of the Gateway API to use. | `string` | `"v1.2.1"` | no |
 | <a name="input_gracefully_destroy_nodes"></a> [gracefully\_destroy\_nodes](#input\_gracefully\_destroy\_nodes) | Whether to gracefully destroy nodes. | `bool` | `false` | no |
-| <a name="input_hosts"></a> [hosts](#input\_hosts) | A map of current hosts from which to build the Talos cluster. | <pre>map(object({<br/>    role = string<br/>    install = object({<br/>      diskSelectors   = list(string) # https://www.talos.dev/v1.9/reference/configuration/v1alpha1/config/#Config.machine.install.diskSelector<br/>      extraKernelArgs = optional(list(string), [])<br/>      extensions      = optional(list(string), [])<br/>      secureboot      = optional(bool, false)<br/>      wipe            = optional(bool, false)<br/>      architecture    = optional(string, "amd64")<br/>      platform        = optional(string, "metal")<br/><br/>    })<br/>    interfaces = list(object({<br/>      hardwareAddr     = string<br/>      addresses        = list(string)<br/>      dhcp_routeMetric = optional(number, 100)<br/>      vlans = list(object({<br/>        vlanId           = number<br/>        addresses        = list(string)<br/>        dhcp_routeMetric = optional(number, 100)<br/>      }))<br/>    }))<br/>  }))</pre> | n/a | yes |
+| <a name="input_hosts"></a> [hosts](#input\_hosts) | A map of current hosts from which to build the Talos cluster. | <pre>map(object({<br/>    role = string<br/>    install = object({<br/>      diskSelectors   = list(string) # https://www.talos.dev/v1.9/reference/configuration/v1alpha1/config/#Config.machine.install.diskSelector<br/>      extraKernelArgs = optional(list(string), [])<br/>      extensions      = optional(list(string), [])<br/>      secureboot      = optional(bool, false)<br/>      wipe            = optional(bool, false)<br/>      architecture    = optional(string, "amd64")<br/>      platform        = optional(string, "metal")<br/>    })<br/>    interfaces = list(object({<br/>      hardwareAddr     = string<br/>      addresses        = list(string)<br/>      dhcp_routeMetric = optional(number, 100)<br/>      vlans = list(object({<br/>        vlanId           = number<br/>        addresses        = list(string)<br/>        dhcp_routeMetric = optional(number, 100)<br/>      }))<br/>    }))<br/>  }))</pre> | n/a | yes |
 | <a name="input_kube_config_path"></a> [kube\_config\_path](#input\_kube\_config\_path) | The path to output the Kubernetes configuration file. | `string` | `"~/.kube"` | no |
 | <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | The version of kubernetes to deploy. | `string` | `"1.30.1"` | no |
 | <a name="input_nameservers"></a> [nameservers](#input\_nameservers) | A list of nameservers to use for the Talos cluster. | `list(string)` | <pre>[<br/>  "1.1.1.1",<br/>  "1.0.0.1"<br/>]</pre> | no |
 | <a name="input_ntp_servers"></a> [ntp\_servers](#input\_ntp\_servers) | A list of NTP servers to use for the Talos cluster. | `list(string)` | <pre>[<br/>  "0.pool.ntp.org",<br/>  "1.pool.ntp.org"<br/>]</pre> | no |
 | <a name="input_prometheus_crd_version"></a> [prometheus\_crd\_version](#input\_prometheus\_crd\_version) | The version of the Prometheus CRD to use. | `string` | `"17.0.2"` | no |
+| <a name="input_run_talos_upgrade"></a> [run\_talos\_upgrade](#input\_run\_talos\_upgrade) | Weather or not to run `talosctl upgrade`.  This should be set to true only after the cluster has been created. | `bool` | `false` | no |
 | <a name="input_spegal_version"></a> [spegal\_version](#input\_spegal\_version) | The version of Spegal to use. | `string` | `"v0.0.28"` | no |
 | <a name="input_talos_config_path"></a> [talos\_config\_path](#input\_talos\_config\_path) | The path to output the Talos configuration file. | `string` | `"~/.talos"` | no |
 | <a name="input_talos_version"></a> [talos\_version](#input\_talos\_version) | The version of Talos to use. | `string` | `"v1.8.3"` | no |

--- a/modules/talos-cluster/image.tf
+++ b/modules/talos-cluster/image.tf
@@ -38,7 +38,7 @@ data "talos_image_factory_urls" "host_image_url" {
 
 # Hack: https://github.com/siderolabs/terraform-provider-talos/issues/140
 resource "null_resource" "talos_upgrade_trigger" {
-  depends_on = [talos_machine_configuration_apply.hosts]
+  depends_on = [data.talos_cluster_health.this]
   for_each   = var.hosts
 
   triggers = {

--- a/modules/talos-cluster/output.tf
+++ b/modules/talos-cluster/output.tf
@@ -1,7 +1,7 @@
 resource "local_sensitive_file" "machineconf" {
   for_each        = data.talos_machine_configuration.this
   content         = each.value.machine_configuration
-  filename        = pathexpand("${var.talos_config_path}/machine_configuration-${each.key}.yaml")
+  filename        = pathexpand("${var.talos_config_path}/${var.cluster_name}-${each.key}-machine_configuration.yaml")
   file_permission = "0600"
 }
 

--- a/modules/talos-cluster/tests/harness/talos/main.tf
+++ b/modules/talos-cluster/tests/harness/talos/main.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_version = ">= 1.6.6"
+  required_providers {
+    external = {
+      source  = "hashicorp/external"
+      version = "2.3.4"
+    }
+  }
+}
+
+variable "node" {
+  description = "The node to check."
+  type        = string
+}
+
+variable "talos_config_path" {
+  description = "The path to the talos config file."
+  type        = string
+}
+
+data "external" "talos_version" {
+  program = ["bash", "${path.module}/resources/get_version.sh"]
+
+  query = {
+    talos_config_path = var.talos_config_path
+    node              = var.node
+  }
+}
+
+output "talos_version" {
+  value = data.external.talos_version.result.talos_version
+}

--- a/modules/talos-cluster/tests/harness/talos/main.tf
+++ b/modules/talos-cluster/tests/harness/talos/main.tf
@@ -19,10 +19,10 @@ variable "talos_config_path" {
 }
 
 data "external" "talos_version" {
-  program = ["bash", "${path.module}/resources/get_version.sh"]
+  program = ["bash", pathexpand("${path.module}/resources/get_version.sh")]
 
   query = {
-    talos_config_path = var.talos_config_path
+    talos_config_path = pathexpand(var.talos_config_path)
     node              = var.node
   }
 }

--- a/modules/talos-cluster/tests/harness/talos/resources/get_version.sh
+++ b/modules/talos-cluster/tests/harness/talos/resources/get_version.sh
@@ -5,6 +5,6 @@ set -e
 # https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external#processing-json-in-shell-scripts
 eval "$(jq -r '@sh "TALOS_CONFIG_PATH=\(.talos_config_path) NODE=\(.node)"')"
 
-VERSION=$(talosctl --talosconfig "$TALOS_CONFIG_PATH" --nodes "$NODE" version | jq -r '.client.version')
+VERSION=$(talosctl --talosconfig "$TALOS_CONFIG_PATH" --nodes "$NODE" version --short | grep "Tag:" | awk '{print $2}')
 
 jq -n --arg talos_version "$VERSION" '{"talos_version":$talos_version}'

--- a/modules/talos-cluster/tests/harness/talos/resources/get_version.sh
+++ b/modules/talos-cluster/tests/harness/talos/resources/get_version.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+# https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external#processing-json-in-shell-scripts
+eval "$(jq -r '@sh "TALOS_CONFIG_PATH=\(.talos_config_path) NODE=\(.node)"')"
+
+VERSION=$(talosctl --talosconfig "$TALOS_CONFIG_PATH" --nodes "$NODE" version | jq -r '.client.version')
+
+jq -n --arg talos_version "$VERSION" '{"talos_version":$talos_version}'

--- a/modules/talos-cluster/tests/harness/wait/main.tf
+++ b/modules/talos-cluster/tests/harness/wait/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.6.6"
+  required_providers {
+    time = {
+      source  = "hashicorp/time"
+      version = "0.12.1"
+    }
+  }
+}
+
+variable "duration" {
+  description = "The duration to wait for the cluster to become healthy."
+  type        = string
+  default     = "120s"
+}
+
+resource "time_sleep" "wait" {
+  create_duration = var.duration
+}

--- a/modules/talos-cluster/tests/multi-node.tftest.hcl
+++ b/modules/talos-cluster/tests/multi-node.tftest.hcl
@@ -1,0 +1,93 @@
+run "random" {
+  module {
+    source = "./tests/harness/random"
+  }
+}
+
+run "setup" {
+  variables {
+    cluster_name       = run.random.resource_name
+    cluster_endpoint   = "https://dev.k8s.tomnowak.work:6443"
+    kubernetes_version = "1.30.2"
+    nameservers        = ["192.168.10.1"]
+    hosts = {
+      node44 = {
+        role = "controlplane"
+        install = {
+          diskSelectors = ["type: 'ssd'"]
+        }
+        interfaces = [
+          {
+            hardwareAddr = "ac:1f:6b:2d:ba:1e"
+            addresses    = ["192.168.10.218"]
+            vlans        = []
+          }
+        ]
+      }
+      node45 = {
+        role = "controlplane"
+        install = {
+          diskSelectors = ["type: 'ssd'"]
+        }
+        interfaces = [
+          {
+            hardwareAddr = "ac:1f:6b:2d:bf:ce"
+            addresses    = ["192.168.10.222"]
+            vlans        = []
+          }
+        ]
+      }
+      node46 = {
+        role = "controlplane"
+        install = {
+          diskSelectors = ["type: 'ssd'"]
+        }
+        interfaces = [
+          {
+            hardwareAddr = "ac:1f:6b:2d:c0:22"
+            addresses    = ["192.168.10.246"]
+            vlans        = []
+          }
+        ]
+      }
+    }
+  }
+}
+
+run "kubernetes" {
+  module {
+    source = "./tests/harness/kubernetes"
+  }
+
+  variables {
+    kubeconfig_host                   = run.setup.kubeconfig_host
+    kubeconfig_client_certificate     = run.setup.kubeconfig_client_certificate
+    kubeconfig_client_key             = run.setup.kubeconfig_client_key
+    kubeconfig_cluster_ca_certificate = run.setup.kubeconfig_cluster_ca_certificate
+  }
+
+  assert {
+    condition     = length(data.kubernetes_nodes.this.nodes) == 3
+    error_message = "Incorrect number of nodes: ${length(data.kubernetes_nodes.this.nodes)}"
+  }
+
+  assert {
+    condition     = alltrue([for node in data.kubernetes_nodes.this.nodes : contains(["node44", "node45", "node46"], node.metadata[0].name)])
+    error_message = "A kubernetes node has an incorrect name."
+  }
+
+  assert {
+    condition     = alltrue([for node in data.kubernetes_nodes.this.nodes : contains(["192.168.10.218", "192.168.10.222", "192.168.10.246"], node.status[0].addresses[0].address)])
+    error_message = "A kubernetes node has an incorrect address."
+  }
+
+  assert {
+    condition     = alltrue([for node in data.kubernetes_nodes.this.nodes : node.spec[0].unschedulable == false])
+    error_message = "A kubernetes node is unschedulable."
+  }
+
+  assert {
+    condition     = data.kubernetes_server_version.this.version == "1.30.2"
+    error_message = "Incorrect kubernetes server version: ${data.kubernetes_server_version.this.version}"
+  }
+}

--- a/modules/talos-cluster/tests/single-node-upgrade-k8s.tftest.hcl
+++ b/modules/talos-cluster/tests/single-node-upgrade-k8s.tftest.hcl
@@ -1,0 +1,65 @@
+run "random" {
+  module {
+    source = "./tests/harness/random"
+  }
+}
+
+variables {
+  cluster_name     = run.random.resource_name
+  cluster_endpoint = "https://192.168.10.246:6443"
+  hosts = {
+    node46 = {
+      role = "controlplane"
+      install = {
+        diskSelectors = ["type: 'ssd'"]
+      }
+      interfaces = [
+        {
+          hardwareAddr = "ac:1f:6b:2d:c0:22"
+          addresses    = ["192.168.10.246"]
+          vlans        = []
+        }
+      ]
+    }
+  }
+}
+
+run "setup" {
+  variables {
+    kubernetes_version = "1.30.1"
+  }
+}
+
+run "upgrade" {
+  variables {
+    kubernetes_version = "1.30.2"
+  }
+}
+
+run "wait" {
+  module {
+    source = "./tests/harness/wait"
+  }
+
+  variables {
+    duration = "30s"
+  }
+}
+
+run "kubernetes" {
+  module {
+    source = "./tests/harness/kubernetes"
+  }
+
+  variables {
+    kubeconfig_host                   = run.upgrade.kubeconfig_host
+    kubeconfig_client_certificate     = run.upgrade.kubeconfig_client_certificate
+    kubeconfig_client_key             = run.upgrade.kubeconfig_client_key
+    kubeconfig_cluster_ca_certificate = run.upgrade.kubeconfig_cluster_ca_certificate
+  }
+
+  assert {
+    condition     = data.kubernetes_server_version.this.version == "1.30.2"
+    error_message = "Incorrect kubernetes server version: ${data.kubernetes_server_version.this.version}"
+  }
+}

--- a/modules/talos-cluster/tests/single-node-upgrade-talos.tftest.hcl
+++ b/modules/talos-cluster/tests/single-node-upgrade-talos.tftest.hcl
@@ -6,7 +6,7 @@ run "random" {
 
 variables {
   cluster_name     = run.random.resource_name
-  cluster_endpoint = "https://192.168.10.218:6443"
+  cluster_endpoint = "https://192.168.10.246:6443"
   hosts = {
     node44 = {
       role = "controlplane"
@@ -15,8 +15,8 @@ variables {
       }
       interfaces = [
         {
-          hardwareAddr = "ac:1f:6b:2d:ba:1e"
-          addresses    = ["192.168.10.218"]
+          hardwareAddr = "ac:1f:6b:2d:c0:22"
+          addresses    = ["192.168.10.246"]
           vlans        = []
         }
       ]

--- a/modules/talos-cluster/tests/single-node-upgrade-talos.tftest.hcl
+++ b/modules/talos-cluster/tests/single-node-upgrade-talos.tftest.hcl
@@ -8,7 +8,7 @@ variables {
   cluster_name     = run.random.resource_name
   cluster_endpoint = "https://192.168.10.246:6443"
   hosts = {
-    node44 = {
+    node46 = {
       role = "controlplane"
       install = {
         diskSelectors = ["type: 'ssd'"]
@@ -44,24 +44,22 @@ run "wait" {
   }
 
   variables {
-    duration = "120s"
+    duration = "120s" // No idea how long this should be, does it even need to wait?
   }
 }
 
-run "kubernetes" {
+run "talos" {
   module {
-    source = "./tests/harness/kubernetes"
+    source = "./tests/harness/talos"
   }
 
   variables {
-    kubeconfig_host                   = run.upgrade.kubeconfig_host
-    kubeconfig_client_certificate     = run.upgrade.kubeconfig_client_certificate
-    kubeconfig_client_key             = run.upgrade.kubeconfig_client_key
-    kubeconfig_cluster_ca_certificate = run.upgrade.kubeconfig_cluster_ca_certificate
+    talos_config_path = run.upgrade.local_sensitive_file.talosconfig.filename
+    node              = "node46"
   }
 
   assert {
-    condition     = data.kubernetes_server_version.this.version == "1.30.1"
-    error_message = "Incorrect kubernetes server version: ${data.kubernetes_server_version.this.version}"
+    condition     = data.external.talos_version.this.result.talos_version == "v1.8.4"
+    error_message = "Incorrect talos version: ${data.external.talos_version.this.result.talos_version}"
   }
 }

--- a/modules/talos-cluster/tests/single-node-upgrade-talos.tftest.hcl
+++ b/modules/talos-cluster/tests/single-node-upgrade-talos.tftest.hcl
@@ -1,0 +1,67 @@
+run "random" {
+  module {
+    source = "./tests/harness/random"
+  }
+}
+
+variables {
+  cluster_name     = run.random.resource_name
+  cluster_endpoint = "https://192.168.10.218:6443"
+  hosts = {
+    node44 = {
+      role = "controlplane"
+      install = {
+        diskSelectors = ["type: 'ssd'"]
+      }
+      interfaces = [
+        {
+          hardwareAddr = "ac:1f:6b:2d:ba:1e"
+          addresses    = ["192.168.10.218"]
+          vlans        = []
+        }
+      ]
+    }
+  }
+}
+
+run "setup" {
+  variables {
+    talos_version     = "v1.8.3"
+    run_talos_upgrade = false
+  }
+}
+
+run "upgrade" {
+  variables {
+    talos_version     = "v1.8.4"
+    run_talos_upgrade = true
+  }
+}
+
+run "wait" {
+  module {
+    source = "./tests/harness/wait"
+  }
+
+  variables {
+    duration = "120s"
+  }
+}
+
+run "kubernetes" {
+  module {
+    source = "./tests/harness/kubernetes"
+  }
+
+  variables {
+    kubeconfig_host                   = run.upgrade.kubeconfig_host
+    kubeconfig_client_certificate     = run.upgrade.kubeconfig_client_certificate
+    kubeconfig_client_key             = run.upgrade.kubeconfig_client_key
+    kubeconfig_cluster_ca_certificate = run.upgrade.kubeconfig_cluster_ca_certificate
+  }
+
+  assert {
+    condition     = data.kubernetes_server_version.this.version == "1.30.1"
+    error_message = "Incorrect kubernetes server version: ${data.kubernetes_server_version.this.version}"
+  }
+}

--- a/modules/talos-cluster/variables.tf
+++ b/modules/talos-cluster/variables.tf
@@ -129,7 +129,6 @@ variable "hosts" {
       wipe            = optional(bool, false)
       architecture    = optional(string, "amd64")
       platform        = optional(string, "metal")
-
     })
     interfaces = list(object({
       hardwareAddr     = string
@@ -157,4 +156,10 @@ variable "hosts" {
     condition     = alltrue([for host in var.hosts : host.role == "worker" || host.role == "controlplane"])
     error_message = "The host role must be either 'worker', 'controlplane'."
   }
+}
+
+variable "run_talos_upgrade" {
+  description = "Weather or not to run `talosctl upgrade`.  This should be set to true only after the cluster has been created."
+  type        = bool
+  default     = false
 }

--- a/modules/talos-cluster/versions.tf
+++ b/modules/talos-cluster/versions.tf
@@ -17,5 +17,9 @@ terraform {
       source  = "hashicorp/time"
       version = "0.12.1"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = "3.2.3"
+    }
   }
 }


### PR DESCRIPTION
This pull request includes several changes to the `modules/talos-cluster` module, primarily focused on adding support for the `null` provider, introducing a Talos upgrade mechanism, and enhancing testing capabilities. The most important changes include updates to the README, the addition of a new resource for triggering Talos upgrades, and improvements to test configurations.

### Enhancements to Talos upgrade mechanism:

* Added `null` provider requirement and provider details in `modules/talos-cluster/README.md`. [[1]](diffhunk://#diff-b96f6747d1b221804e3fb90880b64f5667a175fd6ecb35655062b1da7c8ba3e8R11) [[2]](diffhunk://#diff-b96f6747d1b221804e3fb90880b64f5667a175fd6ecb35655062b1da7c8ba3e8R21)
* Introduced `null_resource.talos_upgrade_trigger` to handle Talos upgrades based on a state marker and image URL.
* Added `run_talos_upgrade` variable to control whether the Talos upgrade should be executed. [[1]](diffhunk://#diff-b96f6747d1b221804e3fb90880b64f5667a175fd6ecb35655062b1da7c8ba3e8L63-R72) [[2]](diffhunk://#diff-167e1ece077519ca5187e10d9cf4f91181dfbab251d7f51df23804224e87e3c5R160-R165)

### Improvements to testing capabilities:

* Added new test harness configurations for Talos and Kubernetes upgrades in `modules/talos-cluster/tests/`. [[1]](diffhunk://#diff-e3479ae973edef44761a1cd559fb0e1a0b5cc465f3ca36a295bc38c042dade5bR1-R93) [[2]](diffhunk://#diff-55ecda8eb3bd559aea15925e5064f4c698190c7d16c62c0425ca9e8f93e45f1fR1-R65) [[3]](diffhunk://#diff-3b9e92a3d9ea1c72941e1595c57080664e5a3ba1a4fe777903830c679d3cac1aR1-R84)
* Introduced a script to fetch Talos version in `modules/talos-cluster/tests/harness/talos/resources/get_version.sh`.

### General updates:

* Updated the file naming pattern for machine configuration files in `modules/talos-cluster/output.tf`.
* Added new Terraform configurations for required providers and versions in `modules/talos-cluster/tests/harness/talos/main.tf` and `modules/talos-cluster/tests/harness/wait/main.tf`. [[1]](diffhunk://#diff-4041f68673aeca75dd04591655c1058b54b6875e2236fea0c9c7b387bf5b4821R1-R32) [[2]](diffhunk://#diff-31d9d7c7e85b0faf74f8b7673ac2a8f1d1bde76eb3bb15f300f15565a8286099R1-R19)