### PR TITLE
Add Bootstrap module path var

### DIFF
--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -84,6 +84,7 @@ No modules.
 | <a name="input_flux_version"></a> [flux\_version](#input\_flux\_version) | Version of Flux to install | `string` | `"v2.4.0"` | no |
 | <a name="input_github_org"></a> [github\_org](#input\_github\_org) | Github organization | `string` | n/a | yes |
 | <a name="input_github_repository"></a> [github\_repository](#input\_github\_repository) | Github repository | `string` | n/a | yes |
+| <a name="input_github_repository_path"></a> [github\_repository\_path](#input\_github\_repository\_path) | Path in the Github repository to the cluster configuration | `string` | `"clusters"` | no |
 | <a name="input_github_token"></a> [github\_token](#input\_github\_token) | Github token | `string` | n/a | yes |
 | <a name="input_kubernetes_config_file_path"></a> [kubernetes\_config\_file\_path](#input\_kubernetes\_config\_file\_path) | Path to the kubeconfig file | `string` | n/a | yes |
 

--- a/modules/bootstrap/flux.tf
+++ b/modules/bootstrap/flux.tf
@@ -6,6 +6,6 @@ resource "flux_bootstrap_git" "this" {
   depends_on = [data.github_repository.this]
 
   version                = var.flux_version
-  path                   = "clusters/${var.cluster_name}"
+  path                   = "${var.github_repository_path}/${var.cluster_name}"
   kustomization_override = file("${path.module}/resources/kustomization.yaml")
 }

--- a/modules/bootstrap/variables.tf
+++ b/modules/bootstrap/variables.tf
@@ -24,6 +24,12 @@ variable "github_repository" {
   type        = string
 }
 
+variable "github_repository_path" {
+  description = "Path in the Github repository to the cluster configuration"
+  type        = string
+  default     = "clusters"
+}
+
 variable "github_token" {
   description = "Github token"
   type        = string


### PR DESCRIPTION
This pull request includes updates to the `flux_bootstrap_git` resource and the addition of a new variable in the `bootstrap` module to improve the flexibility of specifying the GitHub repository path for cluster configurations.

Changes to the `flux_bootstrap_git` resource:

* [`modules/bootstrap/flux.tf`](diffhunk://#diff-dc35d4d885a8b1d2169814090a0dc6ffe5de2ba1671b40bc87069b10fd0868ddL9-R9): Updated the `path` attribute to use the new `github_repository_path` variable, allowing for more flexible configuration of the repository path.

Addition of a new variable:

* [`modules/bootstrap/variables.tf`](diffhunk://#diff-5ed7624289c0b67c7c11d6d805d89b83d234f3de4142e361585887dbbf9c049eR27-R32): Added a new variable `github_repository_path` with a default value of "clusters" to specify the path in the GitHub repository for cluster configurations.… for repository path