### PR TITLE
Talos Cluster Smart Upgrade

### DIFF
--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -86,7 +86,7 @@ No modules.
 | <a name="input_github_repository"></a> [github\_repository](#input\_github\_repository) | Github repository | `string` | n/a | yes |
 | <a name="input_github_repository_path"></a> [github\_repository\_path](#input\_github\_repository\_path) | Path in the Github repository to the cluster configuration | `string` | `"clusters"` | no |
 | <a name="input_github_token"></a> [github\_token](#input\_github\_token) | Github token | `string` | n/a | yes |
-| <a name="input_kubernetes_config_file_path"></a> [kubernetes\_config\_file\_path](#input\_kubernetes\_config\_file\_path) | Path to the kubeconfig file | `string` | n/a | yes |
+| <a name="input_kubernetes_config_path"></a> [kubernetes\_config\_path](#input\_kubernetes\_config\_path) | Path to the kubeconfig file | `string` | n/a | yes |
 
 ## Outputs
 

--- a/modules/talos-cluster/README.md
+++ b/modules/talos-cluster/README.md
@@ -20,7 +20,6 @@
 | <a name="provider_local"></a> [local](#provider\_local) | 2.5.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | 3.2.3 |
 | <a name="provider_talos"></a> [talos](#provider\_talos) | 0.7.0 |
-| <a name="provider_time"></a> [time](#provider\_time) | 0.12.1 |
 
 ## Modules
 
@@ -39,11 +38,11 @@ No modules.
 | [talos_machine_bootstrap.this](https://registry.terraform.io/providers/siderolabs/talos/0.7.0/docs/resources/machine_bootstrap) | resource |
 | [talos_machine_configuration_apply.machines](https://registry.terraform.io/providers/siderolabs/talos/0.7.0/docs/resources/machine_configuration_apply) | resource |
 | [talos_machine_secrets.this](https://registry.terraform.io/providers/siderolabs/talos/0.7.0/docs/resources/machine_secrets) | resource |
-| [time_sleep.wait](https://registry.terraform.io/providers/hashicorp/time/0.12.1/docs/resources/sleep) | resource |
 | [helm_template.cilium](https://registry.terraform.io/providers/hashicorp/helm/2.17.0/docs/data-sources/template) | data source |
 | [talos_client_configuration.this](https://registry.terraform.io/providers/siderolabs/talos/0.7.0/docs/data-sources/client_configuration) | data source |
 | [talos_cluster_health.k8s_api_available](https://registry.terraform.io/providers/siderolabs/talos/0.7.0/docs/data-sources/cluster_health) | data source |
 | [talos_cluster_health.this](https://registry.terraform.io/providers/siderolabs/talos/0.7.0/docs/data-sources/cluster_health) | data source |
+| [talos_cluster_health.upgrade](https://registry.terraform.io/providers/siderolabs/talos/0.7.0/docs/data-sources/cluster_health) | data source |
 | [talos_image_factory_extensions_versions.machine_version](https://registry.terraform.io/providers/siderolabs/talos/0.7.0/docs/data-sources/image_factory_extensions_versions) | data source |
 | [talos_image_factory_urls.machine_image_url](https://registry.terraform.io/providers/siderolabs/talos/0.7.0/docs/data-sources/image_factory_urls) | data source |
 | [talos_machine_configuration.this](https://registry.terraform.io/providers/siderolabs/talos/0.7.0/docs/data-sources/machine_configuration) | data source |
@@ -73,7 +72,7 @@ No modules.
 | <a name="input_machine_network_nameservers"></a> [machine\_network\_nameservers](#input\_machine\_network\_nameservers) | A list of nameservers to use for the Talos cluster. | `list(string)` | <pre>[<br/>  "1.1.1.1",<br/>  "1.0.0.1"<br/>]</pre> | no |
 | <a name="input_machine_time_servers"></a> [machine\_time\_servers](#input\_machine\_time\_servers) | A list of NTP servers to use for the Talos cluster. | `list(string)` | <pre>[<br/>  "0.pool.ntp.org",<br/>  "1.pool.ntp.org"<br/>]</pre> | no |
 | <a name="input_machines"></a> [machines](#input\_machines) | A list of machines to create the talos cluster from. | <pre>map(object({<br/>    type = string<br/>    install = object({<br/>      diskSelectors   = list(string) # https://www.talos.dev/v1.9/reference/configuration/v1alpha1/config/#Config.machine.install.diskSelector<br/>      extraKernelArgs = optional(list(string), [])<br/>      extensions      = optional(list(string), [])<br/>      secureboot      = optional(bool, false)<br/>      wipe            = optional(bool, false)<br/>      architecture    = optional(string, "amd64")<br/>      platform        = optional(string, "metal")<br/>    })<br/>    files = optional(list(object({<br/>      content     = string<br/>      permissions = string<br/>      path        = string<br/>      op          = string<br/>    })), [])<br/>    interfaces = list(object({<br/>      hardwareAddr     = string<br/>      addresses        = list(string)<br/>      dhcp_routeMetric = optional(number, 100)<br/>      vlans = optional(list(object({<br/>        vlanId           = number<br/>        addresses        = list(string)<br/>        dhcp_routeMetric = optional(number, 100)<br/>      })), [])<br/>    }))<br/>  }))</pre> | n/a | yes |
-| <a name="input_run_talos_upgrade"></a> [run\_talos\_upgrade](#input\_run\_talos\_upgrade) | Weather or not to run `talosctl upgrade`.  This should be set to true only after the cluster has been created. | `bool` | `false` | no |
+| <a name="input_stage_talos_upgrade"></a> [stage\_talos\_upgrade](#input\_stage\_talos\_upgrade) | Weather or not to stage talos upgrades.  If this is set to false, the upgrade will be applied immediately and node will reboot. | `bool` | `false` | no |
 | <a name="input_talos_config_path"></a> [talos\_config\_path](#input\_talos\_config\_path) | The path to output the Talos configuration file. | `string` | `"~/.talos"` | no |
 | <a name="input_talos_version"></a> [talos\_version](#input\_talos\_version) | The version of Talos to use. | `string` | `"v1.9.0"` | no |
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | The timeout to use for the Talos cluster. | `string` | `"10m"` | no |
@@ -86,4 +85,5 @@ No modules.
 | <a name="output_kubeconfig_client_key"></a> [kubeconfig\_client\_key](#output\_kubeconfig\_client\_key) | n/a |
 | <a name="output_kubeconfig_cluster_ca_certificate"></a> [kubeconfig\_cluster\_ca\_certificate](#output\_kubeconfig\_cluster\_ca\_certificate) | n/a |
 | <a name="output_kubeconfig_host"></a> [kubeconfig\_host](#output\_kubeconfig\_host) | n/a |
+| <a name="output_script_path"></a> [script\_path](#output\_script\_path) | n/a |
 <!-- END_TF_DOCS -->

--- a/modules/talos-cluster/cilium.tf
+++ b/modules/talos-cluster/cilium.tf
@@ -27,7 +27,7 @@ data "helm_template" "cilium" {
       cilium_version           = var.cilium_version
       gracefully_destroy_nodes = var.gracefully_destroy_nodes
       timeout                  = var.timeout
-      run_talos_upgrade        = var.run_talos_upgrade
+      stage_talos_upgrade      = var.stage_talos_upgrade
     })
   ]
 }

--- a/modules/talos-cluster/health.tf
+++ b/modules/talos-cluster/health.tf
@@ -1,16 +1,3 @@
-# This prevents the module from reporting completion until the cluster is up and operational.
-# tflint-ignore: terraform_unused_declarations
-data "talos_cluster_health" "this" {
-  client_configuration   = data.talos_client_configuration.this.client_configuration
-  endpoints              = local.controlplane_ips
-  control_plane_nodes    = local.controlplane_ips
-  skip_kubernetes_checks = false
-
-  timeouts = {
-    read = var.timeout
-  }
-}
-
 # This reports healthy when kube api is available.
 # tflint-ignore: terraform_unused_declarations
 data "talos_cluster_health" "k8s_api_available" {
@@ -24,9 +11,37 @@ data "talos_cluster_health" "k8s_api_available" {
   }
 }
 
+# This prevents the module from reporting completion until the cluster is up and operational.
+# tflint-ignore: terraform_unused_declarations
+data "talos_cluster_health" "this" {
+  client_configuration   = data.talos_client_configuration.this.client_configuration
+  endpoints              = local.controlplane_ips
+  control_plane_nodes    = local.controlplane_ips
+  skip_kubernetes_checks = false
+
+  timeouts = {
+    read = var.timeout
+  }
+}
+
+# This reports healthy when the cluster is upgraded.
+# tflint-ignore: terraform_unused_declarations
+data "talos_cluster_health" "upgrade" {
+  depends_on = [null_resource.talos_upgrade_trigger]
+
+  client_configuration   = data.talos_client_configuration.this.client_configuration
+  endpoints              = local.controlplane_ips
+  control_plane_nodes    = local.controlplane_ips
+  skip_kubernetes_checks = false
+
+  timeouts = {
+    read = var.timeout
+  }
+}
+
 # The above can be unreliable...  Use this to kick off helm deployments in that case.
 # tflint-ignore: terraform_unused_declarations
-resource "time_sleep" "wait" {
-  depends_on      = [talos_cluster_kubeconfig.this]
-  create_duration = "120s"
-}
+#resource "time_sleep" "wait" {
+#  depends_on      = [talos_cluster_kubeconfig.this]
+#  create_duration = "120s"
+#}

--- a/modules/talos-cluster/resources/scripts/upgrade-node.sh
+++ b/modules/talos-cluster/resources/scripts/upgrade-node.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# Expects the following environment variables set:
+#   DESIRED_TALOS_TAG
+#   DESIRED_TALOS_SCHEMATIC
+#   TALOS_CONFIG_PATH
+#   TALOS_NODE
+#   STAGE
+#   TIMEOUT
+
+if [ -z "$DESIRED_TALOS_TAG" ] || [ -z "$DESIRED_TALOS_SCHEMATIC" ] || [ -z "$TALOS_CONFIG_PATH" ] || [ -z "$TALOS_NODE" ] || [ -z "$STAGE" ] || [ -z "$TIMEOUT" ]; then
+  echo "Missing required environment variables."
+  exit 1
+fi
+
+CURRENT_TALOS_SCHEMATIC=$(talosctl --talosconfig "$TALOS_CONFIG_PATH" --nodes "$TALOS_NODE" get extensions -o json 2>/dev/null| jq -s '.[] | select(.spec.metadata.name == "schematic") | .spec.metadata.version' | tr -d '"')
+CURRENT_TALOS_TAG=$(talosctl --talosconfig "$TALOS_CONFIG_PATH" --nodes "$TALOS_NODE" version --short 2>/dev/null | grep 'Tag:' | awk '{print $2}')
+
+echo Current Schematic: $CURRENT_TALOS_SCHEMATIC Desired Schematic: $DESIRED_TALOS_SCHEMATIC
+echo Current Tag: $CURRENT_TALOS_TAG Desired Tag: $DESIRED_TALOS_TAG
+
+if [ "$DESIRED_TALOS_TAG" = "$CURRENT_TALOS_TAG" ] && [ "$DESIRED_TALOS_SCHEMATIC" = "$CURRENT_TALOS_SCHEMATIC" ]; then
+  echo "No Upgrade required."
+else
+  echo "Upgrade required."
+  talosctl --talosconfig $TALOS_CONFIG_PATH --nodes "$TALOS_NODE" upgrade --image="factory.talos.dev/installer/$DESIRED_TALOS_SCHEMATIC:$DESIRED_TALOS_TAG" --timeout=$TIMEOUT
+fi

--- a/modules/talos-cluster/tests/multi-node-apply.tftest.hcl
+++ b/modules/talos-cluster/tests/multi-node-apply.tftest.hcl
@@ -6,7 +6,7 @@ run "random" {
 
 run "setup" {
   variables {
-    run_talos_upgrade = true
+    stage_talos_upgrade = true
 
     cluster_name                           = run.random.resource_name
     cluster_endpoint                       = "dev.k8s.tomnowak.work"

--- a/modules/talos-cluster/tests/multi-node-upgrade-talos.tftest.hcl
+++ b/modules/talos-cluster/tests/multi-node-upgrade-talos.tftest.hcl
@@ -6,7 +6,7 @@ run "random" {
 
 
 variables {
-  run_talos_upgrade = true
+  stage_talos_upgrade = true
 
   cluster_name                           = run.random.resource_name
   cluster_endpoint                       = "dev.k8s.tomnowak.work"

--- a/modules/talos-cluster/tests/plan.tftest.hcl
+++ b/modules/talos-cluster/tests/plan.tftest.hcl
@@ -132,7 +132,7 @@ run "test" {
         ]
       }
     }
-    run_talos_upgrade = true
+    stage_talos_upgrade = true
   }
 
   # talos_machine_secrets.this

--- a/modules/talos-cluster/tests/single-node-apply.tftest.hcl
+++ b/modules/talos-cluster/tests/single-node-apply.tftest.hcl
@@ -6,10 +6,8 @@ run "random" {
 
 run "setup" {
   variables {
-    run_talos_upgrade = true
-
     cluster_name                           = run.random.resource_name
-    cluster_endpoint                       = "192.168.10.246"
+    cluster_endpoint                       = "192.168.10.218"
     cluster_allowSchedulingOnControlPlanes = true
 
     kubernetes_version          = "1.30.2"
@@ -19,15 +17,15 @@ run "setup" {
     machine_time_servers        = ["0.pool.ntp.org", "1.pool.ntp.org"]
 
     machines = {
-      node46 = {
+      node44 = {
         type = "controlplane"
         install = {
           diskSelectors = ["type: 'ssd'"]
         }
         interfaces = [
           {
-            hardwareAddr = "ac:1f:6b:2d:c0:22"
-            addresses    = ["192.168.10.246"]
+            hardwareAddr = "ac:1f:6b:2d:ba:1e"
+            addresses    = ["192.168.10.218"]
           }
         ]
       }
@@ -53,12 +51,12 @@ run "kubernetes" {
   }
 
   assert {
-    condition     = data.kubernetes_nodes.this.nodes[0].metadata[0].name == "node46"
+    condition     = data.kubernetes_nodes.this.nodes[0].metadata[0].name == "node44"
     error_message = "Incorrect node name: ${data.kubernetes_nodes.this.nodes[0].metadata[0].name}"
   }
 
   assert {
-    condition     = data.kubernetes_nodes.this.nodes[0].status[0].addresses[0].address == "192.168.10.246"
+    condition     = data.kubernetes_nodes.this.nodes[0].status[0].addresses[0].address == "192.168.10.218"
     error_message = "Incorrect node address: ${data.kubernetes_nodes.this.nodes[0].status[0].addresses[0].address}"
   }
 
@@ -80,7 +78,7 @@ run "talos" {
 
   variables {
     talos_config_path = "~/.talos/${run.random.resource_name}.yaml"
-    node              = "node46"
+    node              = "node44"
   }
 
   assert {
@@ -94,7 +92,7 @@ run "talos" {
   }
 
   assert {
-    condition     = data.external.talos_info.result["interfaces"] == "{\"hardwareAddr\":\"ac:1f:6b:2d:c0:22\",\"addresses\":[\"192.168.10.246/24\"]}"
+    condition     = data.external.talos_info.result["interfaces"] == "{\"hardwareAddr\":\"ac:1f:6b:2d:ba:1e\",\"addresses\":[\"192.168.10.218/24\"]}"
     error_message = "Incorrect interfaces: ${data.external.talos_info.result["interfaces"]}"
   }
 
@@ -118,4 +116,3 @@ run "talos" {
     error_message = "Incorrect machine type: ${data.external.talos_info.result["machine_type"]}"
   }
 }
-

--- a/modules/talos-cluster/tests/single-node-upgrade.tftest.hcl
+++ b/modules/talos-cluster/tests/single-node-upgrade.tftest.hcl
@@ -5,22 +5,19 @@ run "random" {
 }
 
 variables {
-  run_talos_upgrade = true
-
   cluster_name     = run.random.resource_name
-  cluster_endpoint = "192.168.10.246"
+  cluster_endpoint = "192.168.10.218"
 
   machines = {
-    node46 = {
+    node44 = {
       type = "controlplane"
       install = {
         diskSelectors = ["type: 'ssd'"]
       }
       interfaces = [
         {
-          hardwareAddr = "ac:1f:6b:2d:c0:22"
-          addresses    = ["192.168.10.246"]
-          vlans        = []
+          hardwareAddr = "ac:1f:6b:2d:ba:1e"
+          addresses    = ["192.168.10.218"]
         }
       ]
     }
@@ -33,7 +30,6 @@ run "setup" {
   }
 }
 
-
 run "talos_version_check" {
   module {
     source = "./tests/harness/talos"
@@ -41,7 +37,7 @@ run "talos_version_check" {
 
   variables {
     talos_config_path = "~/.talos/${run.random.resource_name}.yaml"
-    node              = "node46"
+    node              = "node44"
   }
 
   assert {
@@ -49,7 +45,6 @@ run "talos_version_check" {
     error_message = "Incorrect talos version: ${data.external.talos_info.result["talos_version"]}"
   }
 }
-
 
 run "upgrade" {
   variables {
@@ -64,7 +59,7 @@ run "talos_upgrade_check" {
 
   variables {
     talos_config_path = "~/.talos/${run.random.resource_name}.yaml"
-    node              = "node46"
+    node              = "node44"
   }
 
   assert {

--- a/modules/talos-cluster/variables.tf
+++ b/modules/talos-cluster/variables.tf
@@ -241,8 +241,8 @@ variable "machines" {
   }
 }
 
-variable "run_talos_upgrade" {
-  description = "Weather or not to run `talosctl upgrade`.  This should be set to true only after the cluster has been created."
+variable "stage_talos_upgrade" {
+  description = "Weather or not to stage talos upgrades.  If this is set to false, the upgrade will be applied immediately and node will reboot."
   type        = bool
   default     = false
 }


### PR DESCRIPTION
This pull request includes several changes to improve the Talos cluster module, focusing on renaming variables, adding new outputs, and updating scripts and tests. The most important changes include renaming the `run_talos_upgrade` variable to `stage_talos_upgrade`, adding a new output for the script path, and updating the Talos cluster health checks.

### Variable and Configuration Updates:
* Renamed the `run_talos_upgrade` variable to `stage_talos_upgrade` across multiple files to better reflect its purpose. (`[[1]](diffhunk://#diff-27287ffbb1aedf14cbf5ef1778bd076d6789692f650b1cea10728fdc9cf78383L30-R30)`, `[[2]](diffhunk://#diff-167e1ece077519ca5187e10d9cf4f91181dfbab251d7f51df23804224e87e3c5L244-R245)`)
* Updated the `kubernetes_config_file_path` variable to `kubernetes_config_path` in the `modules/bootstrap/README.md` file. (`[modules/bootstrap/README.mdL89-R89](diffhunk://#diff-bd5921b8a577642992c2bfe274b53343b3324b282f98c9f77bbaa9ffc0918016L89-R89)`)

### Output and Resource Additions:
* Added a new output `script_path` to provide the path to the upgrade script. (`[[1]](diffhunk://#diff-b9e94216dc713f47be81c7237ff333729fa6386461c2cbfaf182649247d850abR38-R64)`, `[[2]](diffhunk://#diff-b96f6747d1b221804e3fb90880b64f5667a175fd6ecb35655062b1da7c8ba3e8R88)`)
* Added a new data source `talos_cluster_health.k8s_api_available` for checking Kubernetes API availability. (`[modules/talos-cluster/health.tfR1-R13](diffhunk://#diff-8c0ae6d2299743edc12a3b7e064c683c4758b9951761ee04e4931224d0d3e2f8R1-R13)`)

### Script and Health Check Enhancements:
* Introduced a new script `upgrade-node.sh` to handle Talos node upgrades. (`[modules/talos-cluster/resources/scripts/upgrade-node.shR1-R27](diffhunk://#diff-1f8a9560550d828583f54c249a778769a22ae0e450a713261084111e45227525R1-R27)`)
* Updated the Talos cluster health checks to include a new `upgrade` check and modified the existing `k8s_api_available` check. (`[[1]](diffhunk://#diff-8c0ae6d2299743edc12a3b7e064c683c4758b9951761ee04e4931224d0d3e2f8L14-R35)`, `[[2]](diffhunk://#diff-8c0ae6d2299743edc12a3b7e064c683c4758b9951761ee04e4931224d0d3e2f8L29-R47)`)

### Test Adjustments:
* Renamed and updated test files to reflect the variable name changes and new configurations. (`[[1]](diffhunk://#diff-f18eb1a0efdbae28803aea6060d2ab8380ebf303e987eef12cc0d1e19ebaf1a8L8-R20)`, `[[2]](diffhunk://#diff-fffa9fbdd2a22415ed3b1e6c7d5d6e5eb163f56dab1ac2fbadec79abead8afedL9-R9)`, `[[3]](diffhunk://#diff-6069e9f7f72a417d224771d292204f3f58fc0b4480027d4fdfc12f5afd492641L135-R135)`, `[[4]](diffhunk://#diff-6f328b37a55ad3ac907d481cca0a0d5f390b2d4e0d513230663f50c461e90d7aL9-R10)`, `[[5]](diffhunk://#diff-6f328b37a55ad3ac907d481cca0a0d5f390b2d4e0d513230663f50c461e90d7aL22-R28)`, `[[6]](diffhunk://#diff-6f328b37a55ad3ac907d481cca0a0d5f390b2d4e0d513230663f50c461e90d7aL56-R59)`, `[[7]](diffhunk://#diff-6f328b37a55ad3ac907d481cca0a0d5f390b2d4e0d513230663f50c461e90d7aL83-R81)`, `[[8]](diffhunk://#diff-6f328b37a55ad3ac907d481cca0a0d5f390b2d4e0d513230663f50c461e90d7aL97-R95)`, `[[9]](diffhunk://#diff-6f328b37a55ad3ac907d481cca0a0d5f390b2d4e0d513230663f50c461e90d7aL121)`)