### PR TITLE
Add Optional Values to unifi-users

### DIFF
--- a/modules/unifi-users/README.md
+++ b/modules/unifi-users/README.md
@@ -69,7 +69,7 @@ No modules.
 | <a name="input_unifi_password"></a> [unifi\_password](#input\_unifi\_password) | The password to use for the Unifi controller. | `string` | `null` | no |
 | <a name="input_unifi_site"></a> [unifi\_site](#input\_unifi\_site) | The site to use for the Unifi controller. | `string` | `"default"` | no |
 | <a name="input_unifi_username"></a> [unifi\_username](#input\_unifi\_username) | The username to use for the Unifi controller. | `string` | `null` | no |
-| <a name="input_unifi_users"></a> [unifi\_users](#input\_unifi\_users) | List of users to add to the Unifi controller. | <pre>map(object({<br/>    ip  = string<br/>    mac = string<br/>  }))</pre> | n/a | yes |
+| <a name="input_unifi_users"></a> [unifi\_users](#input\_unifi\_users) | List of users to add to the Unifi controller. | <pre>map(object({<br/>    mac = string<br/>    ip  = string<br/><br/>    allow_existing         = optional(bool, true)<br/>    blocked                = optional(bool, null)<br/>    local_dns_record       = optional(bool, null)<br/>    network_id             = optional(string, null)<br/>    skip_forget_on_destroy = optional(bool, false)<br/>  }))</pre> | n/a | yes |
 
 ## Outputs
 

--- a/modules/unifi-users/main.tf
+++ b/modules/unifi-users/main.tf
@@ -8,5 +8,12 @@ resource "unifi_user" "user" {
   name     = each.key
   mac      = each.value.mac
   fixed_ip = each.value.ip
-  note     = local.note
+
+  allow_existing         = each.value.allow_existing
+  blocked                = each.value.blocked
+  local_dns_record       = each.value.local_dns_record
+  network_id             = each.value.network_id
+  skip_forget_on_destroy = each.value.skip_forget_on_destroy
+
+  note = local.note
 }

--- a/modules/unifi-users/main.tftest.hcl
+++ b/modules/unifi-users/main.tftest.hcl
@@ -19,4 +19,39 @@ run "test" {
     condition     = unifi_user.user["a"].fixed_ip == "192.168.169.42"
     error_message = "User IP does not match expected IP."
   }
+
+  assert {
+    condition     = unifi_user.user["a"].mac == "00:1a:2b:3c:4d:5e"
+    error_message = "User MAC does not match expected MAC."
+  }
+
+  assert {
+    condition     = unifi_user.user["a"].note == "Managed by Terraform."
+    error_message = "User note does not match expected note."
+  }
+
+  assert {
+    condition     = unifi_user.user["a"].allow_existing == true
+    error_message = "User allow_existing does not match expected allow_existing."
+  }
+
+  assert {
+    condition     = unifi_user.user["a"].blocked == null
+    error_message = "User blocked does not match expected blocked."
+  }
+
+  assert {
+    condition     = unifi_user.user["a"].local_dns_record == null
+    error_message = "User local_dns_record does not match expected local_dns_record."
+  }
+
+  assert {
+    condition     = unifi_user.user["a"].network_id == null
+    error_message = "User network_id does not match expected network_id."
+  }
+
+  assert {
+    condition     = unifi_user.user["a"].skip_forget_on_destroy == false
+    error_message = "User skip_forget_on_destroy does not match expected skip_forget_on_destroy."
+  }
 }

--- a/modules/unifi-users/variables.tf
+++ b/modules/unifi-users/variables.tf
@@ -24,7 +24,13 @@ variable "unifi_password" {
 variable "unifi_users" {
   description = "List of users to add to the Unifi controller."
   type = map(object({
-    ip  = string
     mac = string
+    ip  = string
+
+    allow_existing         = optional(bool, true)
+    blocked                = optional(bool, null)
+    local_dns_record       = optional(bool, null)
+    network_id             = optional(string, null)
+    skip_forget_on_destroy = optional(bool, false)
   }))
 }


### PR DESCRIPTION
This pull request includes updates to the Unifi users module to enhance the user configuration options and improve the test coverage. The most important changes include adding new optional fields to the user configuration, updating the README to reflect these changes, and adding new assertions to the test file.

Enhancements to user configuration:

* [`modules/unifi-users/variables.tf`](diffhunk://#diff-350d8848bdd22854bb0345576f2fb0ca73035af04aee3759b7dc5ec604e050f1L27-R34): Added new optional fields (`allow_existing`, `blocked`, `local_dns_record`, `network_id`, `skip_forget_on_destroy`) to the `unifi_users` variable definition.
* [`modules/unifi-users/main.tf`](diffhunk://#diff-ef4fdc1b64535ca814e298dc8adc1b1758199d1bcb1781a388a57630f62f39c0R11-R17): Updated the `unifi_user` resource to include the new optional fields.

Documentation updates:

* [`modules/unifi-users/README.md`](diffhunk://#diff-4691317f1c57e4552db34525d8f337ff1f8c51ee039fdaf13859b41fbd329670L72-R72): Updated the description of the `unifi_users` input variable to include the new optional fields.

Improved test coverage:

* [`modules/unifi-users/main.tftest.hcl`](diffhunk://#diff-b1103747cf916bf39df1cfb4f815a6449084e32596133776736b9de2a3c3f6faR22-R56): Added new assertions to test the new optional fields in the `unifi_user` resource.