### PR TITLE
Cluster output filenames

### DIFF
--- a/modules/talos-cluster/README.md
+++ b/modules/talos-cluster/README.md
@@ -86,5 +86,8 @@ No modules.
 | <a name="output_kubeconfig_client_certificate"></a> [kubeconfig\_client\_certificate](#output\_kubeconfig\_client\_certificate) | n/a |
 | <a name="output_kubeconfig_client_key"></a> [kubeconfig\_client\_key](#output\_kubeconfig\_client\_key) | n/a |
 | <a name="output_kubeconfig_cluster_ca_certificate"></a> [kubeconfig\_cluster\_ca\_certificate](#output\_kubeconfig\_cluster\_ca\_certificate) | n/a |
+| <a name="output_kubeconfig_filename"></a> [kubeconfig\_filename](#output\_kubeconfig\_filename) | n/a |
 | <a name="output_kubeconfig_host"></a> [kubeconfig\_host](#output\_kubeconfig\_host) | n/a |
+| <a name="output_machineconf_filenames"></a> [machineconf\_filenames](#output\_machineconf\_filenames) | n/a |
+| <a name="output_talosconfig_filename"></a> [talosconfig\_filename](#output\_talosconfig\_filename) | n/a |
 <!-- END_TF_DOCS -->

--- a/modules/talos-cluster/output.tf
+++ b/modules/talos-cluster/output.tf
@@ -5,16 +5,28 @@ resource "local_sensitive_file" "machineconf" {
   file_permission = "0644"
 }
 
+output "machineconf_filenames" {
+  value = [for f in local_sensitive_file.machineconf : f.filename]
+}
+
 resource "local_sensitive_file" "talosconfig" {
   content         = data.talos_client_configuration.this.talos_config
   filename        = pathexpand("${var.talos_config_path}/${var.cluster_name}.yaml")
   file_permission = "0644"
 }
 
+output "talosconfig_filename" {
+  value = local_sensitive_file.talosconfig.filename
+}
+
 resource "local_sensitive_file" "kubeconfig" {
   content         = talos_cluster_kubeconfig.this.kubeconfig_raw
   filename        = pathexpand("${var.kube_config_path}/${var.cluster_name}.yaml")
   file_permission = "0644"
+}
+
+output "kubeconfig_filename" {
+  value = local_sensitive_file.kubeconfig.filename
 }
 
 output "kubeconfig_host" {


### PR DESCRIPTION
This pull request includes updates to the `modules/talos-cluster` module to add new output variables for filenames. These changes enhance the module's functionality by providing additional outputs for configuration files.

### Enhancements to output variables:

* [`modules/talos-cluster/README.md`](diffhunk://#diff-b96f6747d1b221804e3fb90880b64f5667a175fd6ecb35655062b1da7c8ba3e8R89-R92): Added new output variables `kubeconfig_filename`, `machineconf_filenames`, and `talosconfig_filename` to the documentation.
* [`modules/talos-cluster/output.tf`](diffhunk://#diff-16ff2e1ce743300432c5d2ccf27e8a281db50b9115007f60e9bc5043672a6e41R8-R31): Added new output blocks for `kubeconfig_filename`, `machineconf_filenames`, and `talosconfig_filename` to capture and expose the filenames of the generated configuration files.