### PR TITLE
Correct incorrect var descriptpion

### DIFF
--- a/modules/talos-cluster/variables.tf
+++ b/modules/talos-cluster/variables.tf
@@ -58,7 +58,7 @@ variable "cluster_proxy_disabled" {
 }
 
 variable "cluster_extraManifests" {
-  description = "A list of extra manifests to apply to the Talos cluster.  The following Prometheus CRDs are autoamtically included: [podmonitors, servicemonitors, probes, prometheusrules]."
+  description = "A list of extra manifests to apply to the Talos cluster."
   type        = list(string)
   default     = []
 }


### PR DESCRIPTION
This pull request includes a minor change to the `modules/talos-cluster/variables.tf` file. The change simplifies the description of the `cluster_extraManifests` variable by removing the specific details about the automatically included Prometheus CRDs.

* [`modules/talos-cluster/variables.tf`](diffhunk://#diff-167e1ece077519ca5187e10d9cf4f91181dfbab251d7f51df23804224e87e3c5L61-R61): Simplified the description of the `cluster_extraManifests` variable by removing the details about Prometheus CRDs.