### PR TITLE
Bootstrap external secrets

### DIFF
--- a/.taskfiles/tofu/taskfile.yaml
+++ b/.taskfiles/tofu/taskfile.yaml
@@ -139,6 +139,7 @@ tasks:
     vars:
       MODULE: "{{index .MATCH 0}}"
     cmds:
+      - tofu -chdir={{.MODULES_DIR}}/{{.MODULE}} init -upgrade
       - tofu -chdir={{.MODULES_DIR}}/{{.MODULE}} validate
     preconditions:
       - which tofu

--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -7,6 +7,7 @@
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | 5.80.0 |
 | <a name="requirement_flux"></a> [flux](#requirement\_flux) | 1.4.0 |
 | <a name="requirement_github"></a> [github](#requirement\_github) | 6.4.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.35.1 |
 
 ## Providers
 
@@ -14,6 +15,7 @@
 |------|---------|
 | <a name="provider_flux"></a> [flux](#provider\_flux) | 1.4.0 |
 | <a name="provider_github"></a> [github](#provider\_github) | 6.4.0 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.35.1 |
 
 ## Modules
 
@@ -24,6 +26,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [flux_bootstrap_git.this](https://registry.terraform.io/providers/fluxcd/flux/1.4.0/docs/resources/bootstrap_git) | resource |
+| [kubernetes_secret.external_secrets_access_key](https://registry.terraform.io/providers/hashicorp/kubernetes/2.35.1/docs/resources/secret) | resource |
 | [github_repository.this](https://registry.terraform.io/providers/integrations/github/6.4.0/docs/data-sources/repository) | data source |
 
 ## Inputs
@@ -31,6 +34,8 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the cluster | `string` | n/a | yes |
+| <a name="input_external_secrets_access_key_id"></a> [external\_secrets\_access\_key\_id](#input\_external\_secrets\_access\_key\_id) | AWS access key ID for external-secrets. | `string` | n/a | yes |
+| <a name="input_external_secrets_access_key_secret"></a> [external\_secrets\_access\_key\_secret](#input\_external\_secrets\_access\_key\_secret) | AWS secret access key for external-secrets. | `string` | n/a | yes |
 | <a name="input_flux_version"></a> [flux\_version](#input\_flux\_version) | Version of Flux to install | `string` | `"v2.4.0"` | no |
 | <a name="input_github_org"></a> [github\_org](#input\_github\_org) | Github organization | `string` | n/a | yes |
 | <a name="input_github_repository"></a> [github\_repository](#input\_github\_repository) | Github repository | `string` | n/a | yes |

--- a/modules/bootstrap/external-secrets.tf
+++ b/modules/bootstrap/external-secrets.tf
@@ -1,5 +1,4 @@
-/*resource "kubernetes_secret" "external_secrets_access_key" {
-  depends_on = [kubernetes_namespace.flux_system]
+resource "kubernetes_secret" "external_secrets_access_key" {
   metadata {
     name      = "external-secrets-access-key"
     namespace = "kube-system"
@@ -10,5 +9,3 @@
     secret_access_key = var.external_secrets_access_key_secret
   }
 }
-*/
-

--- a/modules/bootstrap/providers.tf
+++ b/modules/bootstrap/providers.tf
@@ -11,6 +11,10 @@ provider "flux" {
   }
 }
 
+provider "kubernetes" {
+  config_path = var.kubernetes_config_path
+}
+
 provider "github" {
   owner = var.github_org
   token = var.github_token

--- a/modules/bootstrap/variables.tf
+++ b/modules/bootstrap/variables.tf
@@ -35,7 +35,7 @@ variable "github_token" {
   type        = string
 }
 
-/*
+
 variable "external_secrets_access_key_id" {
   description = "AWS access key ID for external-secrets."
   type        = string
@@ -45,4 +45,4 @@ variable "external_secrets_access_key_secret" {
   description = "AWS secret access key for external-secrets."
   type        = string
 }
-*/
+

--- a/modules/bootstrap/versions.tf
+++ b/modules/bootstrap/versions.tf
@@ -13,5 +13,9 @@ terraform {
       source  = "integrations/github"
       version = "6.4.0"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "2.35.1"
+    }
   }
 }


### PR DESCRIPTION
This pull request includes several changes to the `modules/bootstrap` directory to integrate Kubernetes and external secrets management. The most important changes include adding Kubernetes provider configurations, updating the README to reflect these changes, and uncommenting relevant code sections for external secrets.

Integration of Kubernetes and external secrets management:

* Added Kubernetes provider configuration in `modules/bootstrap/providers.tf`.
* Updated `modules/bootstrap/README.md` to include Kubernetes requirements and resources [[1]](diffhunk://#diff-bd5921b8a577642992c2bfe274b53343b3324b282f98c9f77bbaa9ffc0918016R10-R18) [[2]](diffhunk://#diff-bd5921b8a577642992c2bfe274b53343b3324b282f98c9f77bbaa9ffc0918016R29-R38).
* Uncommented and added `kubernetes_secret` resource for external secrets in `modules/bootstrap/external-secrets.tf` [[1]](diffhunk://#diff-bc620e612dc694c7a906e15b195fedec7913239bf86ce48f1d5366fc89fa04d3L1-R1) [[2]](diffhunk://#diff-bc620e612dc694c7a906e15b195fedec7913239bf86ce48f1d5366fc89fa04d3L13-L14).
* Uncommented variables for external secrets access keys in `modules/bootstrap/variables.tf` [[1]](diffhunk://#diff-5ed7624289c0b67c7c11d6d805d89b83d234f3de4142e361585887dbbf9c049eL38-R38) [[2]](diffhunk://#diff-5ed7624289c0b67c7c11d6d805d89b83d234f3de4142e361585887dbbf9c049eL48-R48).
* Added Kubernetes provider version in `modules/bootstrap/versions.tf`.