### PR TITLE
Talos Upgrade Preserve

### DIFF
--- a/modules/talos-cluster/resources/scripts/upgrade-node.sh
+++ b/modules/talos-cluster/resources/scripts/upgrade-node.sh
@@ -23,5 +23,5 @@ if [ "$DESIRED_TALOS_TAG" = "$CURRENT_TALOS_TAG" ] && [ "$DESIRED_TALOS_SCHEMATI
   echo "No Upgrade required."
 else
   echo "Upgrade required."
-  talosctl --talosconfig $TALOS_CONFIG_PATH --nodes "$TALOS_NODE" upgrade --image="factory.talos.dev/installer/$DESIRED_TALOS_SCHEMATIC:$DESIRED_TALOS_TAG" --timeout=$TIMEOUT
+  talosctl --talosconfig $TALOS_CONFIG_PATH --nodes "$TALOS_NODE" upgrade --image="factory.talos.dev/installer/$DESIRED_TALOS_SCHEMATIC:$DESIRED_TALOS_TAG" --timeout=$TIMEOUT --preserve
 fi


### PR DESCRIPTION
This pull request includes a small but important change to the `modules/talos-cluster/resources/scripts/upgrade-node.sh` file. The change ensures that the `talosctl` command preserves existing configurations during an upgrade.

* [`modules/talos-cluster/resources/scripts/upgrade-node.sh`](diffhunk://#diff-1f8a9560550d828583f54c249a778769a22ae0e450a713261084111e45227525L26-R26): Added the `--preserve` flag to the `talosctl` upgrade command to maintain existing configurations during the upgrade process.…talos-linux-support/\#talos-linux-upgrades