### PR TITLE
Wait to start health check until after bootstrap

### DIFF
--- a/modules/talos-cluster/health.tf
+++ b/modules/talos-cluster/health.tf
@@ -4,6 +4,7 @@
 # This prevents the module from reporting completion until the cluster is up and operational.
 # tflint-ignore: terraform_unused_declarations
 resource "null_resource" "talos_cluster_health" {
+  depends_on = [talos_machine_bootstrap.this]
   triggers = {
     always_run = timestamp()
   }


### PR DESCRIPTION
This pull request includes a small but important change to the `modules/talos-cluster/health.tf` file. The change ensures that the `null_resource` for `talos_cluster_health` depends on the `talos_machine_bootstrap` resource to guarantee that the cluster is fully operational before reporting completion.

* [`modules/talos-cluster/health.tf`](diffhunk://#diff-8c0ae6d2299743edc12a3b7e064c683c4758b9951761ee04e4931224d0d3e2f8R7): Added a `depends_on` attribute to the `null_resource` `talos_cluster_health` to ensure it waits for the `talos_machine_bootstrap` resource.