### PR TITLE
Add extra args for talos

### DIFF
--- a/modules/talos-cluster/README.md
+++ b/modules/talos-cluster/README.md
@@ -55,6 +55,7 @@ No modules.
 | <a name="input_cluster_allowSchedulingOnControlPlanes"></a> [cluster\_allowSchedulingOnControlPlanes](#input\_cluster\_allowSchedulingOnControlPlanes) | Whether to allow scheduling on control plane nodes. | `bool` | `true` | no |
 | <a name="input_cluster_coreDNS_disabled"></a> [cluster\_coreDNS\_disabled](#input\_cluster\_coreDNS\_disabled) | Whether to disable CoreDNS. | `bool` | `false` | no |
 | <a name="input_cluster_endpoint"></a> [cluster\_endpoint](#input\_cluster\_endpoint) | The endpoint for the Talos cluster. | `string` | `"10.10.10.10"` | no |
+| <a name="input_cluster_etcd_extraArgs"></a> [cluster\_etcd\_extraArgs](#input\_cluster\_etcd\_extraArgs) | A list of extra arguments to pass to the etcd service. | <pre>list(object({<br/>    name  = string<br/>    value = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_cluster_extraManifests"></a> [cluster\_extraManifests](#input\_cluster\_extraManifests) | A list of extra manifests to apply to the Talos cluster. | `list(string)` | `[]` | no |
 | <a name="input_cluster_inlineManifests"></a> [cluster\_inlineManifests](#input\_cluster\_inlineManifests) | A list of inline manifests to apply to the Talos cluster. | <pre>list(object({<br/>    name     = string<br/>    contents = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | A name to provide for the Talos cluster. | `string` | `"cluster"` | no |

--- a/modules/talos-cluster/config.tf
+++ b/modules/talos-cluster/config.tf
@@ -45,6 +45,7 @@ data "talos_machine_configuration" "this" {
       cluster_coreDNS_disabled               = var.cluster_coreDNS_disabled
       cluster_extraManifests                 = var.cluster_extraManifests
       cluster_inlineManifests                = var.cluster_inlineManifests
+      cluster_etcd_extraArgs                 = var.cluster_etcd_extraArgs
 
       cilium_manifest = data.helm_template.cilium.manifest
     })

--- a/modules/talos-cluster/resources/talos-patches/cluster_etcd_extraArgs.yaml.tftpl
+++ b/modules/talos-cluster/resources/talos-patches/cluster_etcd_extraArgs.yaml.tftpl
@@ -1,0 +1,12 @@
+# Allow passing extra args to etcd
+# https://www.talos.dev/v1.9/reference/configuration/v1alpha1/config/#Config.cluster.etcd
+---
+%{ if type == "controlplane" }
+cluster:
+  etcd:
+    extraArgs:
+%{ for arg in cluster_etcd_extraArgs ~}
+      - name: ${arg.name}
+        value: ${arg.value}
+%{ endfor ~}
+%{ endif }

--- a/modules/talos-cluster/variables.tf
+++ b/modules/talos-cluster/variables.tf
@@ -72,6 +72,15 @@ variable "cluster_inlineManifests" {
   default = []
 }
 
+variable "cluster_etcd_extraArgs" {
+  description = "A list of extra arguments to pass to the etcd service."
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  default = []
+}
+
 variable "machine_files" {
   description = "A list of files to add to all machines in the cluster. See: https://www.talos.dev/v1.9/reference/configuration/v1alpha1/config/#Config.machine.files."
   type = list(object({


### PR DESCRIPTION
This pull request introduces the ability to pass extra arguments to the etcd service in a Talos cluster. The changes span across multiple files, adding new variables and updating configurations to support this feature.

Key changes include:

### New Variable Addition:
* [`modules/talos-cluster/variables.tf`](diffhunk://#diff-167e1ece077519ca5187e10d9cf4f91181dfbab251d7f51df23804224e87e3c5R75-R83): Added a new variable `cluster_etcd_extraArgs` to allow users to specify extra arguments for the etcd service.

### Documentation Update:
* [`modules/talos-cluster/README.md`](diffhunk://#diff-b96f6747d1b221804e3fb90880b64f5667a175fd6ecb35655062b1da7c8ba3e8R58): Updated the documentation to include the new `cluster_etcd_extraArgs` variable, describing its purpose and default value.

### Configuration Update:
* [`modules/talos-cluster/config.tf`](diffhunk://#diff-d03f508e70f2c7be3a1482f1d13287d849d7e290071c0082ae76f32ccc1b03adR48): Updated the Talos machine configuration to include the new `cluster_etcd_extraArgs` variable, ensuring it is passed correctly.

### Template Update:
* [`modules/talos-cluster/resources/talos-patches/cluster_etcd_extraArgs.yaml.tftpl`](diffhunk://#diff-62827c9b3c81c7d97b276fe4b8ce4f2927eb7b091ee893e03999a6c9a0989030R1-R12): Created a new template file to handle the extra arguments for the etcd service, ensuring they are applied only to control plane nodes.