### PR TITLE
Update cluster module readme and params_put targets

### DIFF
--- a/modules/cluster/README.md
+++ b/modules/cluster/README.md
@@ -1,3 +1,18 @@
+# Cluster Module
+
+This is a highly opinionated implementation of the other modules in this repository.  It's primary purpose is to template deploying kubernetes clusters into my homelab environment, and expose only the levers and knobs which I need access to.  This allows me to make the other modules more generic.
+
+## Overview
+
+In brief, the `cluster` module does the following:
+
+1. Pulls secrets from AWS parameter store via the `params-get` module.
+1. ~~Creates Unifi dns entries for all machines~~
+1. ~~Creates Unifi user records (DHCP Reservations) for all machines~~
+1. Creates a talos cluster from the machines via the `talos-cluster`.
+1. Bootstraps the talos cluster into my [homelab gitops repository](https://github.com/ionfury/homelab/tree/main/kubernetes/clusters) for further management via flux via the `bootstrap` module.
+1. Stores the cluster `kubeconfig` and `talosconfig` secrets in my AWS parameter store.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -268,14 +268,14 @@ module "params_put" {
   aws = var.aws
   parameters = {
     kubeconfig = {
-      name        = "/homelab/infrastructure/${var.cluster_name}/kubeconfig"
-      description = "Managed by Terraform."
+      name        = "/homelab/infrastructure/clusters/${var.cluster_name}/kubeconfig"
+      description = "Kubeconfig for cluster '${var.cluster_name}'."
       type        = "SecureString"
       value       = module.talos_cluster.kubeconfig_raw
     }
     talosconfig = {
-      name        = "/homelab/infrastructure/${var.cluster_name}/talosconfig"
-      description = "Managed by Terraform."
+      name        = "/homelab/infrastructure/clusters/${var.cluster_name}/talosconfig"
+      description = "Talosconfig for cluster '${var.cluster_name}'."
       type        = "SecureString"
       value       = module.talos_cluster.talosconfig_raw
     }

--- a/modules/cluster/tests/main.tftest.hcl
+++ b/modules/cluster/tests/main.tftest.hcl
@@ -7,13 +7,13 @@ run "random" {
 run "test" {
   variables {
     cluster_name     = run.random.resource_name
-    cluster_endpoint = "192.168.10.201"
+    cluster_endpoint = "192.168.10.218"
     tld              = "tomnowak.work"
 
     cluster_vip            = "192.168.10.6"
     cluster_node_subnet    = "192.168.10.0/24"
-    cluster_pod_subnet     = "172.18.0.0/16"
-    cluster_service_subnet = "172.19.0.0/16"
+    cluster_pod_subnet     = "172.30.0.0/16"
+    cluster_service_subnet = "172.31.0.0/16"
 
     cilium_helm_values = <<EOT
 ipam:
@@ -65,17 +65,13 @@ EOT
     timeout           = "10m"
 
     machines = {
-      node43 = {
-        type = "controlplane"
-        install = {
-          diskSelectors = ["type: 'ssd'"]
-        }
-        interfaces = [
-          {
-            hardwareAddr = "ac:1f:6b:2d:bb:c8"
-            addresses    = ["192.168.10.201"]
-          }
-        ]
+      node44 = {
+        type    = "controlplane"
+        install = { diskSelectors = ["type: 'ssd'"] }
+        interfaces = [{
+          hardwareAddr = "ac:1f:6b:2d:ba:1e"
+          addresses    = ["192.168.10.218"]
+        }]
       }
     }
 


### PR DESCRIPTION
This pull request includes updates to the `cluster` module, focusing on documentation, parameter naming, and testing configurations. The most important changes include the addition of a new README file for the `cluster` module, updates to parameter names for better clarity, and modifications to test configurations.

Documentation updates:

* [`modules/cluster/README.md`](diffhunk://#diff-6cf4d7d20db093931400bab84f6b24872b507aebc716ac5dc45091f43c5b43e2R1-R15): Added a new README file for the `cluster` module, providing an overview and detailing its functionality.

Parameter naming updates:

* [`modules/cluster/main.tf`](diffhunk://#diff-b573a5884d86152370a746aac6beaf1185c25ac13f5eb95dfc28264356b6d595L271-R278): Updated parameter names for `kubeconfig` and `talosconfig` to include the `clusters` path for better clarity.

Testing configuration updates:

* [`modules/cluster/tests/main.tftest.hcl`](diffhunk://#diff-1bb51de28d2b888b67d1cf6e0abb4651102dc777f9e7ec557f3df9ecfb431316L10-R16): Modified test configurations, including updates to `cluster_endpoint`, `cluster_pod_subnet`, `cluster_service_subnet`, and machine interface details. [[1]](diffhunk://#diff-1bb51de28d2b888b67d1cf6e0abb4651102dc777f9e7ec557f3df9ecfb431316L10-R16) [[2]](diffhunk://#diff-1bb51de28d2b888b67d1cf6e0abb4651102dc777f9e7ec557f3df9ecfb431316L68-R74)