### PR TITLE
Arbitrary Cluster env vars

### DIFF
--- a/modules/bootstrap/resources/generated-cluster-vars.env.tftpl
+++ b/modules/bootstrap/resources/generated-cluster-vars.env.tftpl
@@ -1,3 +1,3 @@
-%{ for var in cluster_vars ~}
-${var.name}=${var.value}
+%{ for name, value in cluster_vars ~}
+${name}=${value}
 %{ endfor ~}

--- a/modules/bootstrap/variables.tf
+++ b/modules/bootstrap/variables.tf
@@ -108,9 +108,6 @@ variable "cloudflare_tunnel_secret_annotations" {
 
 variable "cluster_env_vars" {
   description = "Environment variables to add to the cluster git repository root directory, to be consumed by flux. See: https://fluxcd.io/flux/components/kustomize/kustomizations/#post-build-variable-substitution"
-  type = list(object({
-    name  = string
-    value = string
-  }))
-  default = []
+  type        = map(string)
+  default     = {}
 }

--- a/modules/cluster/README.md
+++ b/modules/cluster/README.md
@@ -46,6 +46,7 @@ No resources.
 | <a name="input_cilium_version"></a> [cilium\_version](#input\_cilium\_version) | The version of Cilium to use. | `string` | n/a | yes |
 | <a name="input_cloudflare"></a> [cloudflare](#input\_cloudflare) | The Cloudflare account to use. | <pre>object({<br/>    account       = string<br/>    email         = string<br/>    api_key_store = string<br/>  })</pre> | n/a | yes |
 | <a name="input_cluster_endpoint"></a> [cluster\_endpoint](#input\_cluster\_endpoint) | The endpoint for the cluster. | `string` | n/a | yes |
+| <a name="input_cluster_env_vars"></a> [cluster\_env\_vars](#input\_cluster\_env\_vars) | Arbitrary map of values to pass to cluster via the generated-cluster-vars.env. | `map(string)` | n/a | yes |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | A name to provide for the cluster. | `string` | n/a | yes |
 | <a name="input_cluster_node_subnet"></a> [cluster\_node\_subnet](#input\_cluster\_node\_subnet) | The subnet to use for the Talos cluster nodes. | `string` | n/a | yes |
 | <a name="input_cluster_pod_subnet"></a> [cluster\_pod\_subnet](#input\_cluster\_pod\_subnet) | The pod subnet to use for pods on the Talos cluster. | `string` | n/a | yes |

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -15,48 +15,21 @@ locals {
     }
   })
 
-  cluster_env_vars = [
-    {
-      name  = "cluster_name"
-      value = var.cluster_name
-    },
-    {
-      name  = "cluster_endpoint"
-      value = var.cluster_endpoint
-    },
-    {
-      name  = "cluster_vip"
-      value = var.cluster_vip
-    },
-    {
-      name  = "cluster_node_subnet"
-      value = var.cluster_node_subnet
-    },
-    {
-      name  = "cluster_pod_subnet"
-      value = var.cluster_pod_subnet
-    },
-    {
-      name  = "cluster_service_subnet"
-      value = var.cluster_service_subnet
-    },
-    {
-      name  = "talos_version"
-      value = var.talos_version
-    },
-    {
-      name  = "cilium_version"
-      value = var.cilium_version
-    },
-    {
-      name  = "flux_version"
-      value = var.flux_version
-    },
-    {
-      name  = "prometheus_version"
-      value = var.prometheus_version
-    }
-  ]
+  generated_cluster_env_vars = {
+    cluster_name           = var.cluster_name
+    cluster_endpoint       = var.cluster_endpoint
+    cluster_vip            = var.cluster_vip
+    cluster_node_subnet    = var.cluster_node_subnet
+    cluster_pod_subnet     = var.cluster_pod_subnet
+    cluster_service_subnet = var.cluster_service_subnet
+    cluster_path           = "${var.github.repository_path}/${var.cluster_name}"
+    talos_version          = var.talos_version
+    cilium_version         = var.cilium_version
+    flux_version           = var.flux_version
+    prometheus_version     = var.prometheus_version
+  }
+
+  cluster_env_vars = merge(var.cluster_env_vars, local.generated_cluster_env_vars)
 
   cluster_extraManifests = [
     # Prometheus CRDs

--- a/modules/cluster/tests/main.tftest.hcl
+++ b/modules/cluster/tests/main.tftest.hcl
@@ -14,6 +14,9 @@ run "test" {
     cluster_node_subnet    = "192.168.10.0/24"
     cluster_pod_subnet     = "172.30.0.0/16"
     cluster_service_subnet = "172.31.0.0/16"
+    cluster_env_vars = {
+      test = "best"
+    }
 
     cilium_helm_values = <<EOT
 ipam:
@@ -82,8 +85,8 @@ EOT
 
     unifi = {
       address        = "https://192.168.1.1"
-      username_store = "/homelab/unifi/terraform/username" # /homelab/infrastructure/unifi/username
-      password_store = "/homelab/unifi/terraform/password" # /homelab/infrastructure/unifi/password
+      username_store = "/homelab/infrastructure/accounts/unifi/username"
+      password_store = "/homelab/infrastructure/accounts/unifi/password"
       site           = "default"
     }
 
@@ -91,22 +94,22 @@ EOT
       org             = "ionfury"
       repository      = "homelab"
       repository_path = "kubernetes/clusters"
-      token_store     = "/homelab/github/ionfury/homelab-flux-dev-token" # /homelab/infrastructure/github/token
+      token_store     = "/homelab/infrastructure/accounts/github/token"
     }
 
     cloudflare = {
       account       = "homelab"
       email         = "ionfury@gmail.com"
-      api_key_store = "/homelab/cloudflare/api-key" # /homelab/infrastructure/cloudflare/api-key
+      api_key_store = "/homelab/infrastructure/accounts/cloudflare/api-key"
     }
 
     external_secrets = {
-      id_store     = "/homelab/kubernetes/live/external-secrets/id"     # /homelab/infrastructure/external-secrets/id
-      secret_store = "/homelab/kubernetes/live/external-secrets/secret" # /homelab/infrastructure/external-secrets/secret
+      id_store     = "/homelab/infrastructure/accounts/external-secrets/id"
+      secret_store = "/homelab/infrastructure/accounts/external-secrets/secret"
     }
 
     healthchecksio = {
-      api_key_store = "/homelab/healthchecksio/api-key" # /homelab/infrastructure/healthchecksio/api-key
+      api_key_store = "/homelab/infrastructure/accounts/healthchecksio/api-key"
     }
   }
 }

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -38,6 +38,11 @@ variable "cilium_version" {
   type        = string
 }
 
+variable "cluster_env_vars" {
+  description = "Arbitrary map of values to pass to cluster via the generated-cluster-vars.env."
+  type        = map(string)
+}
+
 variable "kubernetes_version" {
   description = "The version of Kubernetes to use."
   type        = string


### PR DESCRIPTION
This pull request includes several changes to improve the handling of cluster environment variables and streamline the configuration files. The most important changes involve switching from a list of objects to a map for environment variables, updating relevant templates and tests, and cleaning up the configuration for better readability and maintainability.

Changes to environment variable handling:

* [`modules/bootstrap/variables.tf`](diffhunk://#diff-5ed7624289c0b67c7c11d6d805d89b83d234f3de4142e361585887dbbf9c049eL111-R112): Changed the `cluster_env_vars` variable type from a list of objects to a map of strings and updated the default value accordingly.
* [`modules/cluster/main.tf`](diffhunk://#diff-b573a5884d86152370a746aac6beaf1185c25ac13f5eb95dfc28264356b6d595L18-R32): Replaced the list of environment variable objects with a map and merged it with user-provided variables.

Template and documentation updates:

* [`modules/bootstrap/resources/generated-cluster-vars.env.tftpl`](diffhunk://#diff-3ec104825d11e806dc7aebb7d5bca7a5a0a55282d20409976d395e42bfc200aeL1-R2): Updated the template to iterate over the new map format for environment variables.
* [`modules/cluster/README.md`](diffhunk://#diff-6cf4d7d20db093931400bab84f6b24872b507aebc716ac5dc45091f43c5b43e2R49): Added documentation for the `cluster_env_vars` input variable.

Test configuration updates:

* [`modules/cluster/tests/main.tftest.hcl`](diffhunk://#diff-1bb51de28d2b888b67d1cf6e0abb4651102dc777f9e7ec557f3df9ecfb431316R17-R19): Added a test case for the new `cluster_env_vars` format and updated paths for storing sensitive data. [[1]](diffhunk://#diff-1bb51de28d2b888b67d1cf6e0abb4651102dc777f9e7ec557f3df9ecfb431316R17-R19) [[2]](diffhunk://#diff-1bb51de28d2b888b67d1cf6e0abb4651102dc777f9e7ec557f3df9ecfb431316L85-R112)