### PR TITLE
Add default_replica_count to cluster env vars

### DIFF
--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -27,6 +27,7 @@ locals {
     cilium_version         = var.cilium_version
     flux_version           = var.flux_version
     prometheus_version     = var.prometheus_version
+    default_replica_count  = min(3, length(var.machines))
   }
 
   cluster_env_vars = merge(var.cluster_env_vars, local.generated_cluster_env_vars)


### PR DESCRIPTION
This pull request includes a small change to the `modules/cluster/main.tf` file. The change introduces a new variable `default_replica_count`, which is set to the minimum of 3 and the length of `var.machines`.

* [`modules/cluster/main.tf`](diffhunk://#diff-b573a5884d86152370a746aac6beaf1185c25ac13f5eb95dfc28264356b6d595R30): Added `default_replica_count` variable to set the minimum of 3 and the length of `var.machines`.