### PR TITLE
Only apply vip to cp node

### DIFF
--- a/modules/talos-cluster/resources/talos-patches/machine_network_interfaces.yaml.tftpl
+++ b/modules/talos-cluster/resources/talos-patches/machine_network_interfaces.yaml.tftpl
@@ -9,10 +9,12 @@ machine:
           hardwareAddr: ${interface.hardwareAddr}
           physical: true
         mtu: 1500
+%{ if type == "controlplane" }
 %{ if cluster_vip != "" }
         vip:
           ip: ${cluster_vip}
-%{ endif}
+%{ endif }
+%{ endif }
         addresses:
 %{ for ip in interface.addresses ~}
           - ${ip}/24


### PR DESCRIPTION
This pull request includes a small change to the `modules/talos-cluster/resources/talos-patches/machine_network_interfaces.yaml.tftpl` file. The change ensures that the `vip` configuration block is only included for control plane nodes when a `cluster_vip` is specified.

* [`modules/talos-cluster/resources/talos-patches/machine_network_interfaces.yaml.tftpl`](diffhunk://#diff-6f4e4ebc69e604ca76bf17a51a39546c83b6bb8b3ebf1d7e72a6fe3c2e7522c7R12-R16): Added conditional logic to include the `vip` configuration block only if the node type is "controlplane" and a `cluster_vip` is specified.