### PR TITLE
Use filipowm/unifi provider

### DIFF
--- a/modules/cluster/README.md
+++ b/modules/cluster/README.md
@@ -32,6 +32,8 @@ No providers.
 | <a name="module_params_get"></a> [params\_get](#module\_params\_get) | ../params-get | n/a |
 | <a name="module_params_put"></a> [params\_put](#module\_params\_put) | ../params-put | n/a |
 | <a name="module_talos_cluster"></a> [talos\_cluster](#module\_talos\_cluster) | ../talos-cluster | n/a |
+| <a name="module_unifi_dns"></a> [unifi\_dns](#module\_unifi\_dns) | ../unifi-dns | n/a |
+| <a name="module_unifi_users"></a> [unifi\_users](#module\_unifi\_users) | ../unifi-users | n/a |
 
 ## Resources
 
@@ -71,7 +73,7 @@ No resources.
 | <a name="input_timeout"></a> [timeout](#input\_timeout) | The timeout to use for the cluster. | `string` | n/a | yes |
 | <a name="input_timeservers"></a> [timeservers](#input\_timeservers) | The timeservers to use for the cluster. | `list(string)` | n/a | yes |
 | <a name="input_tld"></a> [tld](#input\_tld) | The top-level domain to use. | `string` | n/a | yes |
-| <a name="input_unifi"></a> [unifi](#input\_unifi) | The Unifi controller to use. | <pre>object({<br/>    address        = string<br/>    site           = string<br/>    username_store = string<br/>    password_store = string<br/>  })</pre> | n/a | yes |
+| <a name="input_unifi"></a> [unifi](#input\_unifi) | The Unifi controller to use. | <pre>object({<br/>    address       = string<br/>    site          = string<br/>    api_key_store = string<br/>  })</pre> | n/a | yes |
 
 ## Outputs
 

--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -2,8 +2,8 @@ locals {
   # tflint-ignore: terraform_unused_declarations
   unifi_dns_records = tomap({
     for machine, details in var.machines : machine => {
-      name  = var.cluster_endpoint
-      value = details.interfaces[0].addresses[0]
+      name   = var.cluster_endpoint
+      record = details.interfaces[0].addresses[0]
     }
   })
 
@@ -126,8 +126,7 @@ module "params_get" {
 
   aws = var.aws
   parameters = [
-    var.unifi.username_store,
-    var.unifi.password_store,
+    var.unifi.api_key_store,
     var.github.token_store,
     var.external_secrets.id_store,
     var.external_secrets.secret_store,
@@ -135,45 +134,23 @@ module "params_get" {
     var.healthchecksio.api_key_store
   ]
 }
-/*
-This unifi provider is unreliable, getting random errors like the following:
-│ Error: invalid character '<' looking for beginning of value
-│ 
-│   with module.unifi_dns.unifi_dns_record.record["node43"],
-│   on ../unifi-dns/main.tf line 1, in resource "unifi_dns_record" "record":
-│    1: resource "unifi_dns_record" "record" {
-│ 
-Look at the following issues to add support into the mainline provider:
-https://github.com/paultyng/terraform-provider-unifi/issues/460
-https://github.com/paultyng/terraform-provider-unifi/issues/461
 module "unifi_dns" {
   source = "../unifi-dns"
 
   unifi_address     = var.unifi.address
   unifi_site        = var.unifi.site
-  unifi_username    = module.params_get.values[var.unifi.username_store]
-  unifi_password    = module.params_get.values[var.unifi.password_store]
+  unifi_api_key     = module.params_get.values[var.unifi.api_key_store]
   unifi_dns_records = local.unifi_dns_records
 }
-*/
-/*
-╷
-│ Error: not found
-│ 
-│   with module.unifi_users.unifi_user.user["node43"],
-│   on ../unifi-users/main.tf line 5, in resource "unifi_user" "user":
-│    5: resource "unifi_user" "user" {
-│ 
-╵
 module "unifi_users" {
   source = "../unifi-users"
 
-  unifi_address  = var.unifi.address
-  unifi_site     = var.unifi.site
-  unifi_username = module.params_get.values[var.unifi.username_store]
-  unifi_password = module.params_get.values[var.unifi.password_store]
-  unifi_users    = local.unifi_users
-}*/
+  unifi_address = var.unifi.address
+  unifi_site    = var.unifi.site
+  unifi_api_key = module.params_get.values[var.unifi.api_key_store]
+  unifi_users   = local.unifi_users
+}
+
 module "talos_cluster" {
   source = "../talos-cluster"
 

--- a/modules/cluster/tests/main.tftest.hcl
+++ b/modules/cluster/tests/main.tftest.hcl
@@ -7,7 +7,7 @@ run "random" {
 run "test" {
   variables {
     cluster_name     = run.random.resource_name
-    cluster_endpoint = "192.168.10.218"
+    cluster_endpoint = "${run.random.resource_name}.tomnowak.work"
     tld              = "tomnowak.work"
 
     cluster_vip            = "192.168.10.6"
@@ -84,10 +84,9 @@ EOT
     }
 
     unifi = {
-      address        = "https://192.168.1.1"
-      username_store = "/homelab/infrastructure/accounts/unifi/username"
-      password_store = "/homelab/infrastructure/accounts/unifi/password"
-      site           = "default"
+      address       = "https://192.168.1.1"
+      api_key_store = "/homelab/infrastructure/accounts/unifi/api-key"
+      site          = "default"
     }
 
     github = {

--- a/modules/cluster/variables.tf
+++ b/modules/cluster/variables.tf
@@ -182,10 +182,9 @@ variable "aws" {
 variable "unifi" {
   description = "The Unifi controller to use."
   type = object({
-    address        = string
-    site           = string
-    username_store = string
-    password_store = string
+    address       = string
+    site          = string
+    api_key_store = string
   })
 }
 

--- a/modules/unifi-dns/README.md
+++ b/modules/unifi-dns/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8.8 |
-| <a name="requirement_unifi"></a> [unifi](#requirement\_unifi) | 0.41.2 |
+| <a name="requirement_unifi"></a> [unifi](#requirement\_unifi) | 1.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_unifi"></a> [unifi](#provider\_unifi) | 0.41.2 |
+| <a name="provider_unifi"></a> [unifi](#provider\_unifi) | 1.0.0 |
 
 ## Modules
 
@@ -20,17 +20,16 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [unifi_dns_record.record](https://registry.terraform.io/providers/ubiquiti-community/unifi/0.41.2/docs/resources/dns_record) | resource |
+| [unifi_dns_record.record](https://registry.terraform.io/providers/filipowm/unifi/1.0.0/docs/resources/dns_record) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_unifi_address"></a> [unifi\_address](#input\_unifi\_address) | The address of the Unifi controller. | `string` | n/a | yes |
-| <a name="input_unifi_dns_records"></a> [unifi\_dns\_records](#input\_unifi\_dns\_records) | List of DNS records to add to the Unifi controller. | <pre>map(object({<br/>    name        = optional(string, null)<br/>    value       = string<br/>    enabled     = optional(bool, true)<br/>    port        = optional(number, 0)<br/>    priority    = optional(number, 0)<br/>    record_type = optional(string, "A")<br/>    ttl         = optional(number, 0)<br/>  }))</pre> | n/a | yes |
-| <a name="input_unifi_password"></a> [unifi\_password](#input\_unifi\_password) | The password to use for the Unifi controller. | `string` | `null` | no |
+| <a name="input_unifi_api_key"></a> [unifi\_api\_key](#input\_unifi\_api\_key) | The API key to use for the Unifi controller. | `string` | n/a | yes |
+| <a name="input_unifi_dns_records"></a> [unifi\_dns\_records](#input\_unifi\_dns\_records) | List of DNS records to add to the Unifi controller. | <pre>map(object({<br/>    name     = optional(string, null)<br/>    record   = string<br/>    enabled  = optional(bool, true)<br/>    port     = optional(number, null)<br/>    priority = optional(number, null)<br/>    type     = optional(string, "A")<br/>    ttl      = optional(number, 0)<br/>    weight   = optional(number, null)<br/>  }))</pre> | n/a | yes |
 | <a name="input_unifi_site"></a> [unifi\_site](#input\_unifi\_site) | The site to use for the Unifi controller. | `string` | `"default"` | no |
-| <a name="input_unifi_username"></a> [unifi\_username](#input\_unifi\_username) | The username to use for the Unifi controller. | `string` | `null` | no |
 
 ## Outputs
 

--- a/modules/unifi-dns/main.tf
+++ b/modules/unifi-dns/main.tf
@@ -1,11 +1,13 @@
 resource "unifi_dns_record" "record" {
   for_each = var.unifi_dns_records
 
-  name        = coalesce(each.value.name, each.key)
-  value       = each.value.value
-  enabled     = each.value.enabled
-  port        = each.value.port
-  priority    = each.value.priority
-  record_type = each.value.record_type
-  ttl         = each.value.ttl
+  name     = coalesce(each.value.name, each.key)
+  record   = each.value.record
+  enabled  = each.value.enabled
+  port     = each.value.port
+  priority = each.value.priority
+  type     = each.value.type
+  ttl      = each.value.ttl
+  weight   = each.value.weight
 }
+

--- a/modules/unifi-dns/main.tftest.hcl
+++ b/modules/unifi-dns/main.tftest.hcl
@@ -1,30 +1,34 @@
 variables {
-  unifi_address  = "plan"
-  unifi_site     = "plan"
-  unifi_username = "plan"
-  unifi_password = "plan"
+  unifi_address = "https://192.168.1.1"
+  unifi_api_key = "plan"
 
   unifi_dns_records = {
     a = {
-      name  = "a.example.com"
-      value = "192.168.1.1"
+      name   = "a.example.com"
+      record = "192.168.1.1"
     }
     b = {
-      name  = "b.example.com"
-      value = "192.168.1.2"
+      name   = "b.example.com"
+      record = "192.168.1.2"
     }
   }
 }
 
-run "test" {
-  command = plan
+mock_provider "unifi" {
+  alias = "mock"
+}
+
+run "mock" {
+  providers = {
+    unifi = unifi.mock
+  }
 
   assert {
-    condition     = unifi_dns_record.record["a"].value == "192.168.1.1"
+    condition     = unifi_dns_record.record["a"].record == "192.168.1.1"
     error_message = "DNS record value does not match expected value."
   }
   assert {
-    condition     = unifi_dns_record.record["b"].value == "192.168.1.2"
+    condition     = unifi_dns_record.record["b"].record == "192.168.1.2"
     error_message = "DNS record value does not match expected value."
   }
 }

--- a/modules/unifi-dns/provider.tf
+++ b/modules/unifi-dns/provider.tf
@@ -1,7 +1,8 @@
 provider "unifi" {
   api_url        = var.unifi_address
-  username       = var.unifi_username
-  password       = var.unifi_password
+  api_key        = var.unifi_api_key
+  username       = ""
+  password       = ""
   allow_insecure = true
   site           = var.unifi_site
 }

--- a/modules/unifi-dns/variables.tf
+++ b/modules/unifi-dns/variables.tf
@@ -1,3 +1,8 @@
+variable "unifi_api_key" {
+  description = "The API key to use for the Unifi controller."
+  type        = string
+}
+
 variable "unifi_address" {
   description = "The address of the Unifi controller."
   type        = string
@@ -9,31 +14,16 @@ variable "unifi_site" {
   default     = "default"
 }
 
-variable "unifi_username" {
-  description = "The username to use for the Unifi controller."
-  type        = string
-  default     = null
-}
-
-variable "unifi_password" {
-  description = "The password to use for the Unifi controller."
-  type        = string
-  default     = null
-}
-
 variable "unifi_dns_records" {
   description = "List of DNS records to add to the Unifi controller."
   type = map(object({
-    name        = optional(string, null)
-    value       = string
-    enabled     = optional(bool, true)
-    port        = optional(number, 0)
-    priority    = optional(number, 0)
-    record_type = optional(string, "A")
-    ttl         = optional(number, 0)
+    name     = optional(string, null)
+    record   = string
+    enabled  = optional(bool, true)
+    port     = optional(number, null)
+    priority = optional(number, null)
+    type     = optional(string, "A")
+    ttl      = optional(number, 0)
+    weight   = optional(number, null)
   }))
-  validation {
-    condition     = alltrue([for record in var.unifi_dns_records : can(regex("^((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\.?\\b){4}$", record.value))])
-    error_message = "Each DNS record value must be a valid IP address."
-  }
 }

--- a/modules/unifi-dns/versions.tf
+++ b/modules/unifi-dns/versions.tf
@@ -2,8 +2,8 @@ terraform {
   required_version = ">= 1.8.8"
   required_providers {
     unifi = {
-      source  = "ubiquiti-community/unifi"
-      version = "0.41.2"
+      source  = "filipowm/unifi"
+      version = "1.0.0"
     }
   }
 }

--- a/modules/unifi-users/README.md
+++ b/modules/unifi-users/README.md
@@ -43,13 +43,13 @@ No outputs.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8.8 |
-| <a name="requirement_unifi"></a> [unifi](#requirement\_unifi) | 0.41.0 |
+| <a name="requirement_unifi"></a> [unifi](#requirement\_unifi) | 1.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_unifi"></a> [unifi](#provider\_unifi) | 0.41.0 |
+| <a name="provider_unifi"></a> [unifi](#provider\_unifi) | 1.0.0 |
 
 ## Modules
 
@@ -59,16 +59,15 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [unifi_user.user](https://registry.terraform.io/providers/paultyng/unifi/0.41.0/docs/resources/user) | resource |
+| [unifi_user.user](https://registry.terraform.io/providers/filipowm/unifi/1.0.0/docs/resources/user) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_unifi_address"></a> [unifi\_address](#input\_unifi\_address) | The address of the Unifi controller. | `string` | n/a | yes |
-| <a name="input_unifi_password"></a> [unifi\_password](#input\_unifi\_password) | The password to use for the Unifi controller. | `string` | `null` | no |
+| <a name="input_unifi_api_key"></a> [unifi\_api\_key](#input\_unifi\_api\_key) | The API key to use for the Unifi controller. | `string` | n/a | yes |
 | <a name="input_unifi_site"></a> [unifi\_site](#input\_unifi\_site) | The site to use for the Unifi controller. | `string` | `"default"` | no |
-| <a name="input_unifi_username"></a> [unifi\_username](#input\_unifi\_username) | The username to use for the Unifi controller. | `string` | `null` | no |
 | <a name="input_unifi_users"></a> [unifi\_users](#input\_unifi\_users) | List of users to add to the Unifi controller. | <pre>map(object({<br/>    mac = string<br/>    ip  = string<br/><br/>    allow_existing         = optional(bool, true)<br/>    blocked                = optional(bool, null)<br/>    local_dns_record       = optional(bool, null)<br/>    network_id             = optional(string, null)<br/>    skip_forget_on_destroy = optional(bool, false)<br/>  }))</pre> | n/a | yes |
 
 ## Outputs

--- a/modules/unifi-users/main.tftest.hcl
+++ b/modules/unifi-users/main.tftest.hcl
@@ -1,8 +1,6 @@
 variables {
-  unifi_address  = "plan"
-  unifi_site     = "plan"
-  unifi_username = "plan"
-  unifi_password = "plan"
+  unifi_address = "https://192.168.1.1"
+  unifi_api_key = "plan"
 
   unifi_users = {
     a = {
@@ -12,8 +10,14 @@ variables {
   }
 }
 
-run "test" {
-  command = plan
+mock_provider "unifi" {
+  alias = "mock"
+}
+
+run "mock" {
+  providers = {
+    unifi = unifi.mock
+  }
 
   assert {
     condition     = unifi_user.user["a"].fixed_ip == "192.168.169.42"

--- a/modules/unifi-users/provider.tf
+++ b/modules/unifi-users/provider.tf
@@ -1,7 +1,8 @@
 provider "unifi" {
   api_url        = var.unifi_address
-  username       = var.unifi_username
-  password       = var.unifi_password
+  api_key        = var.unifi_api_key
+  username       = ""
+  password       = ""
   allow_insecure = true
   site           = var.unifi_site
 }

--- a/modules/unifi-users/variables.tf
+++ b/modules/unifi-users/variables.tf
@@ -1,3 +1,8 @@
+variable "unifi_api_key" {
+  description = "The API key to use for the Unifi controller."
+  type        = string
+}
+
 variable "unifi_address" {
   description = "The address of the Unifi controller."
   type        = string
@@ -7,18 +12,6 @@ variable "unifi_site" {
   description = "The site to use for the Unifi controller."
   type        = string
   default     = "default"
-}
-
-variable "unifi_username" {
-  description = "The username to use for the Unifi controller."
-  type        = string
-  default     = null
-}
-
-variable "unifi_password" {
-  description = "The password to use for the Unifi controller."
-  type        = string
-  default     = null
 }
 
 variable "unifi_users" {

--- a/modules/unifi-users/versions.tf
+++ b/modules/unifi-users/versions.tf
@@ -2,8 +2,8 @@ terraform {
   required_version = ">= 1.8.8"
   required_providers {
     unifi = {
-      source  = "paultyng/unifi"
-      version = "0.41.0"
+      source  = "filipowm/unifi"
+      version = "1.0.0"
     }
   }
 }


### PR DESCRIPTION
This pull request includes multiple changes across several files to update the Unifi provider and improve the handling of Unifi credentials. The most important changes are grouped by theme and listed below:

### Unifi Provider Update:
* Updated the Unifi provider version from `0.41.x` to `1.0.0` in `modules/unifi-dns/README.md`, `modules/unifi-dns/versions.tf`, `modules/unifi-users/README.md`, and `modules/unifi-users/versions.tf`. [[1]](diffhunk://#diff-92a3c8cb00f6a27c1068da524e4835a5ba3f20a47d31a9f6928234c765c4b52dL7-R13) [[2]](diffhunk://#diff-92a3c8cb00f6a27c1068da524e4835a5ba3f20a47d31a9f6928234c765c4b52dL23-L33) [[3]](diffhunk://#diff-c2f6b0205aa6bc5e762db6f241b253b4922bd0b546655b36356aa7cb2de40f79L5-R6) [[4]](diffhunk://#diff-4691317f1c57e4552db34525d8f337ff1f8c51ee039fdaf13859b41fbd329670L46-R52) [[5]](diffhunk://#diff-4691317f1c57e4552db34525d8f337ff1f8c51ee039fdaf13859b41fbd329670L62-L71) [[6]](diffhunk://#diff-c2f6b0205aa6bc5e762db6f241b253b4922bd0b546655b36356aa7cb2de40f79L5-R6)

### Unifi Credentials Update:
* Replaced `username` and `password` with `api_key` for Unifi controller in `modules/cluster/README.md`, `modules/cluster/main.tf`, `modules/cluster/tests/main.tftest.hcl`, `modules/cluster/variables.tf`, `modules/unifi-dns/README.md`, `modules/unifi-dns/main.tf`, `modules/unifi-dns/main.tftest.hcl`, `modules/unifi-dns/provider.tf`, `modules/unifi-dns/variables.tf`, `modules/unifi-users/README.md`, `modules/unifi-users/main.tftest.hcl`, `modules/unifi-users/provider.tf`, and `modules/unifi-users/variables.tf`. [[1]](diffhunk://#diff-6cf4d7d20db093931400bab84f6b24872b507aebc716ac5dc45091f43c5b43e2L74-R76) [[2]](diffhunk://#diff-b573a5884d86152370a746aac6beaf1185c25ac13f5eb95dfc28264356b6d595L129-R153) [[3]](diffhunk://#diff-1bb51de28d2b888b67d1cf6e0abb4651102dc777f9e7ec557f3df9ecfb431316L88-R88) [[4]](diffhunk://#diff-e72008f602af4cfddabdda539c3933cd8e96d0249c42a2495c653550418e6fb1L187-R187) [[5]](diffhunk://#diff-92a3c8cb00f6a27c1068da524e4835a5ba3f20a47d31a9f6928234c765c4b52dL7-R13) [[6]](diffhunk://#diff-92a3c8cb00f6a27c1068da524e4835a5ba3f20a47d31a9f6928234c765c4b52dL23-L33) [[7]](diffhunk://#diff-85684f94cd41224748d19bce432856c440c076c4f22d26988e7ed7aee5bc2851L5-R13) [[8]](diffhunk://#diff-4e6c30763e14ead1eed203a96b2bc0d839e903019d21d95ba1dae62cb2b72f65L2-R31) [[9]](diffhunk://#diff-b4a04ab400c9a4a4989a0c62ed4edc19c759005de3d8a02eda23e2b1b8f325c9L3-R5) [[10]](diffhunk://#diff-fb7594c0e3899b84db3f44bc89af3f38860ee17a5d1f51235a4f1a64da813f6bR1-R5) [[11]](diffhunk://#diff-fb7594c0e3899b84db3f44bc89af3f38860ee17a5d1f51235a4f1a64da813f6bL12-L38) [[12]](diffhunk://#diff-4691317f1c57e4552db34525d8f337ff1f8c51ee039fdaf13859b41fbd329670L46-R52) [[13]](diffhunk://#diff-4691317f1c57e4552db34525d8f337ff1f8c51ee039fdaf13859b41fbd329670L62-L71) [[14]](diffhunk://#diff-b1103747cf916bf39df1cfb4f815a6449084e32596133776736b9de2a3c3f6faL2-R3) [[15]](diffhunk://#diff-b1103747cf916bf39df1cfb4f815a6449084e32596133776736b9de2a3c3f6faL15-R20) [[16]](diffhunk://#diff-b4a04ab400c9a4a4989a0c62ed4edc19c759005de3d8a02eda23e2b1b8f325c9L3-R5) [[17]](diffhunk://#diff-350d8848bdd22854bb0345576f2fb0ca73035af04aee3759b7dc5ec604e050f1R1-R5) [[18]](diffhunk://#diff-350d8848bdd22854bb0345576f2fb0ca73035af04aee3759b7dc5ec604e050f1L12-L23) [[19]](diffhunk://#diff-c2f6b0205aa6bc5e762db6f241b253b4922bd0b546655b36356aa7cb2de40f79L5-R6)

### DNS Record Handling:
* Changed the DNS record attribute from `value` to `record` in `modules/cluster/main.tf`, `modules/unifi-dns/main.tf`, and `modules/unifi-dns/variables.tf`. [[1]](diffhunk://#diff-b573a5884d86152370a746aac6beaf1185c25ac13f5eb95dfc28264356b6d595L6-R6) [[2]](diffhunk://#diff-85684f94cd41224748d19bce432856c440c076c4f22d26988e7ed7aee5bc2851L5-R13) [[3]](diffhunk://#diff-fb7594c0e3899b84db3f44bc89af3f38860ee17a5d1f51235a4f1a64da813f6bL12-L38)

### Test Configuration:
* Updated test configurations to use `mock_provider` for Unifi in `modules/unifi-dns/main.tftest.hcl` and `modules/unifi-users/main.tftest.hcl`. [[1]](diffhunk://#diff-4e6c30763e14ead1eed203a96b2bc0d839e903019d21d95ba1dae62cb2b72f65L2-R31) [[2]](diffhunk://#diff-b1103747cf916bf39df1cfb4f815a6449084e32596133776736b9de2a3c3f6faL15-R20)

### Miscellaneous:
* Updated the cluster endpoint format in `modules/cluster/tests/main.tftest.hcl`.