### PR TITLE
Only cp nodes should be dns entries

### DIFF
--- a/modules/cluster/main.tf
+++ b/modules/cluster/main.tf
@@ -1,10 +1,12 @@
 locals {
   # tflint-ignore: terraform_unused_declarations
   unifi_dns_records = tomap({
-    for machine, details in var.machines : machine => {
+    for machine, details in var.machines :
+    machine => {
       name   = var.cluster_endpoint
       record = details.interfaces[0].addresses[0]
     }
+    if details.type == "controlplane"
   })
 
   # tflint-ignore: terraform_unused_declarations


### PR DESCRIPTION
This pull request includes a significant change to the `modules/cluster/main.tf` file to enhance the filtering logic for DNS records. The main change involves adding a condition to include only control plane machines in the `unifi_dns_records` map.

Filtering logic improvement:

* [`modules/cluster/main.tf`](diffhunk://#diff-b573a5884d86152370a746aac6beaf1185c25ac13f5eb95dfc28264356b6d595L4-R9): Modified the `unifi_dns_records` local variable to include only machines of type "controlplane" by adding an `if` condition to the `for` expression.